### PR TITLE
Flavor adjustments to Obispo

### DIFF
--- a/After the End Fan Fork/common/dynasties/after_the_end_dynasties.txt
+++ b/After the End Fan Fork/common/dynasties/after_the_end_dynasties.txt
@@ -3514,7 +3514,7 @@
 1849061 = { name="Hewkard" culture=bayfolk }
 1849062 = { name="Macint" culture=bayfolk }
 1849063 = { name="Parc" culture=bayfolk }
-1849064 = { name="Terman" culture=bayfolk }
+1849064 = { name="Madonna" culture=bayfolk }
 1849065 = { name="Litton" culture=bayfolk }
 1849066 = { name="Eitel" culture=bayfolk }
 1849067 = { name="Shockley" culture=bayfolk }
@@ -4830,3 +4830,4 @@
 2007051 = { name="Teseroken" culture=iroquois }
 2007052 = { name="Tetosweken" culture=iroquois }
 2007053 = { name="Yoroonwago" culture=iroquois }
+2007054 = { name="Hearst" culture=bayfolk }

--- a/After the End Fan Fork/common/landed_titles/california.txt
+++ b/After the End Fan Fork/common/landed_titles/california.txt
@@ -529,10 +529,10 @@ e_california = {
 				color2={ 255 255 255 }
 				
 				b_san_luis_obispo_CA = {}
-				b_baywood_CA = {}
+				b_san_simeon_CA = {}
 				b_atascadero_CA = {}
 				b_paso_robles_CA = {}
-				b_templeton_CA = {}
+				b_pismo_beach_CA = {}
 				b_morro_bay_CA = {}
 				b_cambria_CA = {}
 			}

--- a/After the End Fan Fork/history/characters/californias2.txt
+++ b/After the End Fan Fork/history/characters/californias2.txt
@@ -1239,3 +1239,22 @@
 	2642.3.19={birth=yes}
 	2717.12.12={death=yes}
 }
+
+1911148={
+	name="William"
+	female=no
+	dynasty=2007054 # Hearst
+	culture=bayfolk
+	religion=cetic
+	trait=fortune_builder
+	trait=greedy
+	trait=deceitful
+	trait=ambitious
+	martial=3
+	diplomacy=2
+	stewardship=6
+	intrigue=3
+	learning=5
+	2626.9.1={birth=yes}
+	2700.12.1={death=yes}
+}

--- a/After the End Fan Fork/history/provinces/2025 - Obispo.txt
+++ b/After the End Fan Fork/history/provinces/2025 - Obispo.txt
@@ -6,11 +6,11 @@ title = c_obispo
 # Settlements
 max_settlements = 5
 
-b_atascadero_CA = temple
-b_san_luis_obispo_CA = castle
-b_baywood_CA = city
+b_san_luis_obispo_CA = temple
+b_san_simeon_CA = castle
+b_morro_bay_CA = city
 #b_paso_robles_CA = castle
-#b_templeton_CA = city
+#b_atascadero_CA = temple
 
 # Misc
 culture = angeleno

--- a/After the End Fan Fork/history/titles/b_san_simeon_CA.txt
+++ b/After the End Fan Fork/history/titles/b_san_simeon_CA.txt
@@ -1,0 +1,4 @@
+2642.1.3 = {
+	holder = 1911148
+	liege = c_obispo
+}

--- a/After the End Fan Fork/localisation/00_am_titles.csv
+++ b/After the End Fan Fork/localisation/00_am_titles.csv
@@ -495,7 +495,7 @@ b_astoria_OR;Astoria;;;;;;;;;;;;;x
 b_asuncion_nochixtlan_OA;Asunción Nochixtlán;;;;;;;;;;;;;x
 b_atapririre_LLA_adj;Atapririreian;;;;;;;;;;;;;x
 b_atapririre_LLA;Atapririre;;;;;;;;;;;;;x
-b_atascadero_adj;Atascaderian;;atascaderer;;;;;;;;;;;x
+b_atascadero_CA_adj;Atascaderian;;atascaderer;;;;;;;;;;;x
 b_atascadero_CA;Atascadero;Atascadero;Atascadero;;Atascadero;;;;;;;;;x
 b_atascaderos_CH;Atascaderos;;;;;;;;;;;;;x
 b_atchison_KS;Atchison;;;;;;;;;;;;;x
@@ -785,8 +785,6 @@ b_baysville_ON;Baysville;;;;;;;;;;;;;x
 b_baytown_TX;Baytown;;;;;;;;;;;;;x
 b_bayunca_COL_adj;Bayuncaian;;;;;;;;;;;;;x
 b_bayunca_COL;Bayunca;;;;;;;;;;;;;x
-b_baywood_adj;Baywoodian;;baywooder;;;;;;;;;;;x
-b_baywood_CA;Baywood;Baywood;Baywood;;Baywood;;;;;;;;;x
 b_bazan_COL_adj;Bazanian;;;;;;;;;;;;;x
 b_bazan_COL;Bazan;;;;;;;;;;;;;x
 b_beach_ND;Beach;;;;;;;;;;;;;x
@@ -7864,8 +7862,8 @@ b_pipestone_MN;Pipestone;;;;;;;;;;;;;x
 b_pirates_well_BH;Pirates Well;;;;;;;;;;;;;x
 b_piritu_LLA;Piritu;;;;;;;;;;;;;x
 b_pisinemo_AZ;Pisinemo;;;;;;;;;;;;;x
-b_pismo_adj;Pismian;;pismer;;;;;;;;;;;x
-b_pismo_CA;Pismo;Pismo;Pismo;;Pismo;;;;;;;;;x
+b_pismo_beach_CA_adj;Pismian;;pismer;;;;;;;;;;;x
+b_pismo_beach_CA;Pismo;Pismo;Pismo;;Pismo;;;;;;;;;x
 b_pitkin_CO;Pitkin;;;;;;;;;;;;;x
 b_pittsboro_MS;Pittsboro;;;;;;;;;;;;;x
 b_pittsboro_NC;Pittsboro;;;;;;;;;;;;;x
@@ -9063,6 +9061,8 @@ b_san_rafael_del_norte_NI;San Rafael del Norte;;;;;;;;;;;;;x
 b_san_saba_TX;San Saba;;;;;;;;;;;;;x
 b_san_salvador_SV;San Salvador;;;;;;;;;;;;;x
 b_san_sebastian_de_yali_NI;San Sebastián de Yalí;;;;;;;;;;;;;x
+b_san_simeon_CA_adj;San Simeon;;;;;;;;;;;;;x
+b_san_simeon_CA;San Simeon;;;;;;;;;;;;;x
 b_san_simon_MC;San Simon;;;;;;;;;;;;;x
 b_san_telmo_PAN;San Telmo;;;;;;;;;;;;;x
 b_san_timoteo_ZUL_adj;San Timoteoian;;;;;;;;;;;;;x
@@ -10091,8 +10091,6 @@ b_temixco_MX;Temixco;;;;;;;;;;;;;x
 b_temosachic_CH;Temósachic;;;;;;;;;;;;;x
 b_temperance_MI;Temperance;;;;;;;;;;;;;x
 b_temperanceville_VA;Temperanceville;;;;;;;;;;;;;x
-b_templeton_adj;Templetonian;;templetoner;;;;;;;;;;;x
-b_templeton_CA;Templeton;Templeton;Templeton;;Templeton;;;;;;;;;x
 b_tempoal_VE;Tempoal;;;;;;;;;;;;;x
 b_tenabo_YU;Tenabo;;;;;;;;;;;;;x
 b_tenaha_TX;Tenaha;;;;;;;;;;;;;x


### PR DESCRIPTION
These are some flavor adjustments to the county of Obispo in California:
* Baywood removed, as the local area is known as Los Osos, and too small to be distinguished from Morro Bay in this circumstance.
* Templeton removed as it's a smaller community
* Pismo Beach added to give the south county some love
* San Simeon added for the sake of Hearst Castle
* Morro Bay made the default city holding since it controls the bay
* San Simeon made the default castle holding because there's an actual castle there
* San Luis Obispo made the default temple holding because it has a mission
* Made the county holder of the 'Madonna' family. If that family can convince everyone to rename a mountain after them, they can hold on to the county.
* Made William Hearst the default holder of San Simeon to clarify why it's significant.