### PR TITLE
Syntax mixtake in 01_cb_types.txt

### DIFF
--- a/After the End Fan Fork/common/cb_types/01_cb_types.txt
+++ b/After the End Fan Fork/common/cb_types/01_cb_types.txt
@@ -1553,8 +1553,8 @@ liberate_religion = { # New6
 				NOT = { has_character_modifier = holy_war_cooldown }
 				has_game_rule = { name = holy_war_cooldown_rule value = off }
 			}
+			piety = 200
 		}
-		piety = 200
 	}
 	
 	on_add = {


### PR DESCRIPTION
Correction of a syntax mistake that prevented the use of the religious liberation CB.
The requirement for 200 piety was in the wrong scope.