### PR TITLE
Renovator fix.

### DIFF
--- a/After the End Fan Fork/events/horde_events.txt
+++ b/After the End Fan Fork/events/horde_events.txt
@@ -1381,7 +1381,6 @@ character_event = {
 					}
 				}
 				year = 2750
-				NOT = { year = 2750 }
 			}
 			AND = {
 				has_game_rule = {


### PR DESCRIPTION
The line prevented the event from firing altogether.