### PR TITLE
Northwest Cultural Names

### DIFF
--- a/After the End Fan Fork/common/landed_titles/cascadia.txt
+++ b/After the End Fan Fork/common/landed_titles/cascadia.txt
@@ -18,6 +18,11 @@ e_cascadia = {
 		
 		haida = "Haida Tlagaang"	#Tlagaang - One's own country
 		british = "British Columbia"
+		canuck = "Beecee"
+		shuswap = "Swetémtkemc" #people who live downstream
+		wakashan = "Awi'nagwis" #Nuu-chah-nulth word for country
+		dakelh = "Yatoo" #The Ocean
+		ktunaxa = "Aq'asuk" #Ocean Shore
 		
 		mormon = 20
 		raven_tales_reformed = 1000
@@ -31,6 +36,11 @@ e_cascadia = {
 			capital = 548 # Vancouver
 			
 			haida = "Gyúu" 	#Fishing bank
+			canuck = "The Lower Mainland"
+			shuswap = "Selk'emtsín" #shore
+			wakashan = "Tl'aa'aas" #Nuu-chah-nulth word for seaside
+			dakelh = "Nus Sulí" #Mouth of the River
+			ktunaxa = "A'kik'tlu'nam" #City
 			
 			c_beyond_hope = {
 				color = { 255 240 0 }
@@ -38,13 +48,14 @@ e_cascadia = {
 				
 				haida = "Tl'áadaan"	#Canyon/Gorge
 				shuswap = "Scw'exmx"
+				wakashan = "Scw'exmx"
+				dakelh = "Scw'exmx"
+				ktunaxa = "Scw'exmx"
 				
 				b_hope_BC = {}
 				b_lytton_BC = {}
 				b_yale_BC = {}
-				b_boston_bar_BC = {
-					shuswap="Quayome"
-				}
+				b_boston_bar_BC = {}
 				b_hells_gate_BC = {}
 				b_brookmere_BC = {}
 				b_spuzzum_BC = {}
@@ -57,6 +68,9 @@ e_cascadia = {
 				haida = "Táwk'aanaay" #Garden
 				shuswap = "Lummi"
 				canuck = "Bellingham"
+				wakashan = "Lummi"
+				dakelh = "Lummi"
+				ktunaxa = "Lummi"
 				
 				b_bellingham_WA = {}
 				b_abbotsford_BC = {}
@@ -74,17 +88,24 @@ e_cascadia = {
 				
 				haida = "'Langáay" #the group of houses
 				shuswap = "Musqueam"
+				wakashan = "Galdzas Ts'adzis'nukwame'" #'Old' New Vancouver
+				dakelh = "Keyoh" #city
+				ktunaxa = "A'kik'tlu'nam"
 				
 				holy_site = raven_tales
 				holy_site = raven_tales_reformed
 				
-				b_vancouver_BC = {}
+				b_vancouver_BC = {
+					wakashan = "Galdzas Ts'adzis'nukwame'"
+					dakelh = "Keyoh"
+					ktunaxa = "A'kik'tlu'nam" }
 				b_surrey_BC = {}
 				b_richmond_BC = {}
 				b_burnaby_BC = {}
 				b_delta_BC = {}
 				b_coquitlam_BC = {}
-				b_new_westminster_BC = {}
+				b_new_westminster_BC = {
+					shuswap = "Kwinspala" }
 				b_maple_ridge_BC = {}
 				b_tsawwassen_BC = {}
 			}
@@ -94,6 +115,9 @@ e_cascadia = {
 				
 				haida = "K'uhlgwáasgyaan" #Trail across to the other side of something
 				shuswap = "Skwxwú'mesh"
+				wakashan = "Skwxwú'mesh"
+				dakelh = "Skwxwú'mesh"
+				ktunaxa = "Skwxwú'mesh"
 				
 				b_squamish_BC = {}
 				b_whistler_BC = {}
@@ -112,6 +136,9 @@ e_cascadia = {
 				haida = "T'awts'" #Fort. Old name: Súu Káahlii - Lake Valley
 				shuswap = "Stó'lo"
 				canuck = "Chilliwack"
+				wakashan = "Stó'lo"
+				dakelh = "Stó'lo"
+				ktunaxa = "Stó'lo"
 				
 				b_chilliwack_BC = {}
 				b_mission_BC = {}
@@ -134,16 +161,24 @@ e_cascadia = {
 			
 			capital = 550 #Victoria
 			
-			haida = "Jaagúusd"	#west/seaward side of the island
+			haida = "Táwk'aanaay"	#the garden, previously used Jaagúusd, which was also used by Nootka.
+			shuswap = "Metolé"
+			wakashan = "Ts'amas"
+			dakelh = "Saanich"
+			ktunaxa = "Saanich"
 			
 			c_victoria = {
 				color = { 0 99 181 }
 				color2 = { 218 172 94 }
 				
 				haida = "Tlat'uu"	#compound point of a salmon harpoon
-				shuswap = "Saanich"
+				shuswap = "Metolé"
+				wakashan = "Ts'amas"
+				dakelh = "Saanich"
+				ktunaxa = "Saanich"
 				
-				b_victoria_BC = {}
+				b_victoria_BC = {
+					wakashan = "Ts'amas" }
 				b_esquimalt_BC = {}
 				b_saanich_BC = {}
 				b_oak_bay_BC = {}
@@ -161,6 +196,9 @@ e_cascadia = {
 				
 				haida = "Súu" #Lake
 				shuswap = "Qu'wutsun"
+				wakashan = "Nitinaht"
+				dakelh = "Qu'wutsun"
+				ktunaxa = "Qu'wutsun"
 				
 				b_duncan_BC = {}
 				b_lake_cowichan_BC = {}
@@ -182,8 +220,15 @@ e_cascadia = {
 				
 				haida = "K'íijuuyaay"	#The hill/pile
 				shuswap = "Nenámew"
+				wakashan = "Nenámew"
+				dakelh = "Nenámew"
+				ktunaxa = "Nenámew"
 				
-				b_nanaimo_BC = {}
+				b_nanaimo_BC = {
+					shuswap = "Nenámew"
+					wakashan = "Nenámew"
+					dakelh = "Nenámew"
+					ktunaxa = "Nenámew" }
 				b_parksville_BC = {}
 				b_ladysmith_BC = {}
 				b_qualicum_BC = {}
@@ -199,13 +244,16 @@ e_cascadia = {
 				
 				haida = "Gwáayts'aa"	#a group of smaller islands
 				shuswap = "Wenánec"
-				canuck = "Gulf Islands"
+				canuck = "The Gulf Islands"
+				wakashan = "Wenánec"
+				dakelh = "Wenánec"
+				ktunaxa = "Wenánec"
 				
 				b_friday_harbor_WA = {}
 				b_ganges_BC = {}
 				b_eastsound_WA = {}
 				b_vesuvius_BC = {}
-				b_fulford_BC = {}
+				b_fuford_BC = {}
 				b_roche_harbor_WA = {}
 				b_orcas_WA = {}
 				b_lopez_island_WA = {}
@@ -222,9 +270,13 @@ e_cascadia = {
 			color = { 60 156 205 }
 			color2 = { 255 255 255 }
 			
-			culture = haida
+			culture = wakashan
 			
 			haida = "Gujúugalaay"	#the part of an island nearest to a larger landmass
+			shuswap = "K'ómoks"
+			wakashan = "Kwakwaka'wakw"
+			dakelh = "Kwakwaka'wakw"
+			ktunaxa = "K'ómoks"
 			
 			capital = 2091 #Port Hardy
 			
@@ -234,6 +286,9 @@ e_cascadia = {
 				
 				haida = "Jaagúusd" #westward or seaward side of an island
 				shuswap = "Nuu-chah-nulth"
+				wakashan = "Nuu-chah-nulth"
+				dakelh = "Nuu-chah-nulth"
+				ktunaxa = "Nuu-chah-nulth"
 				
 				b_nootka_BC = {}
 				b_tahsis_BC = {}
@@ -249,6 +304,9 @@ e_cascadia = {
 				
 				haida = "K'aadáay" #the dogfish, the shark, previously K'íijuuyaay, shared name with Nanaimo
 				shuswap = "Tla-o-qui-aht"
+				wakashan = "Tla-o-qui-aht"
+				dakelh = "Tla-o-qui-aht"
+				ktunaxa = "Tla-o-qui-aht"
 				
 				b_tofino_BC = {}
 				b_port_alberni_BC = {}
@@ -265,14 +323,21 @@ e_cascadia = {
 				
 				haida = "Tajáaw"	#wind, Old Name: Sahlguda - Barbecue
 				shuswap = "Kwakwaka'wakw"
+				wakashan = "Kwagu'tl"
+				dakelh = "Kwakwaka'wakw"
+				ktunaxa = "Tsaxis"
 				
-				b_port_hardy_BC = {}
+				b_port_hardy_BC = {
+					wakashan = "Tsaxis" }
 				b_port_mcneill_BC = {}
 				b_port_alice_BC = {}
 				b_sayward_BC = {}
-				b_alert_bay_BC = {}
-				b_sointula_BC = {}
-				b_quatsino_BC = {}
+				b_alert_bay_BC = {
+					wakashan = "'Yalis" }
+				b_sointula_BC = {
+					wakashan = "Tlatlask'udis" }
+				b_quatsino_BC = {
+					wakashan = "Gusgimukw" }
 				b_holberg_BC = {}
 				b_woss_BC = {}
 				b_bull_harbour_BC = {}
@@ -287,9 +352,15 @@ e_cascadia = {
 				
 				haida = "T'áws'waal"	#Driftwood, Old name: Gagadáay - stretch of coastline, now used for Duchy of the Coast
 				shuswap = "K'ómoks"
+				wakashan = "K'umuxs'i"
+				dakelh = "K'umuxs'i"
+				ktunaxa = "K'ómoks"
 				
-				b_comox_BC = {}
-				b_campbell_river_BC = {}
+				b_comox_BC = {
+					shuswap = "K'ómoks"
+					wakashan = "K'umuxs'i" }
+				b_campbell_river_BC = {
+					wakashan = "Wiwek'am" }
 				b_courtenay_BC = {}
 				b_cumberland_BC = {}
 				b_oyster_river_BC = {}
@@ -307,13 +378,15 @@ e_cascadia = {
 			color = { 62 80 125 }
 			color2 = { 239 206 0 }
 			
-			culture = haida
+			culture = wakashan
 			
 			capital = 562 #Sunshine Coast
 			
 			haida = "Gagadáay"	#stretch of coastline
 			shuswap = "Kulhuuts" #Nuxalk word for shore
-			canuck = "Central Coast"
+			canuck = "The Central Coast"
+			wakashan = "Gwitala" #highest ranking tribe, northerners
+			dakelh = "'Utna" #west coast first nations people
 		
 			c_sunshine_coast = {
 				color = { 237 235 12 }
@@ -321,19 +394,25 @@ e_cascadia = {
 				
 				haida = "Sangiits'a"	#Sángiits'a - difficult hard challenging
 				shuswap = "Tla'amin"
+				wakashan = "Tla'amin"
+				dakelh = "Tla'amin"
+				ktunaxa = "Tla'amin"
 				
-				b_powell_river_BC = {}
+				b_powell_river_BC = {
+					shuswap = "Tiskw'at" }
 				b_gibsons_BC = {}
 				b_sechelt_BC = {}
 				b_van_anda_BC = {}
 				b_madeira_park_BC = {}
 				b_halfmoon_bay_BC = {}
 				b_egmont_BC = {}
-				b_lund_BC = {}
+				b_lund_BC = {
+					shuswap = "Tla'amin" }
 				b_lang_bay_BC = {}
 				b_stillwater_BC = {}
 				b_saltery_bay_BC = {}
-				b_blubber_bay_BC = {}
+				b_blubber_bay_BC = {
+					shuswap = "Tatlahwech" }
 				b_gillies_bay_BC = {}
 				b_davis_bay_BC = {}
 				b_goat_island_BC = {}
@@ -345,16 +424,21 @@ e_cascadia = {
 				color2 = { 182 182 182 }
 				
 				haida = "Sk'wáay tláay"	#Tide line/high water mark
-				shuswap = "Dzawada'enuxw"
+				shuswap = "Gwa'sala"
+				wakashan = "Gwa'sala"
+				dakelh = "Gwa'sala"
+				ktunaxa = "Gwa'sala"
 				
-				b_kingcome_BC = {}
-				b_hopetown_BC = {}
+				b_kingcome_BC = {
+					wakashan = "Gwa'yi" }
+				b_hopetown_BC = {
+					wakashan = "Hegam's" }
 				b_echo_bay_BC = {}
 				b_sullivan_bay_BC = {}
 				b_thompson_sound_BC = {}
 				b_scott_cove_BC = {}
 				b_health_bay_BC = {
-					shuswap = "Gwayasdums"
+					wakashan = "Gwayasdums"
 				}
 			}
 			c_klinaklini = {
@@ -362,16 +446,20 @@ e_cascadia = {
 				color2 = { 226 199 35 }
 				
 				haida = "Gwáanggaa" #broken, in reference to the coastline's shape
-				shuswap = "Da'naxda'xw"
+				shuswap = "Dzawadi"
+				wakashan = "Dzawadi"
+				dakelh = "Dzawadi"
+				ktunaxa = "Dzawadi"
 				
 				b_port_neville_BC = {}
 				b_roy_BC = {}
 				b_matilpi_BC = {}
 				b_blind_channel_BC = {}
-				b_glendale_cove_BC = {}
+				b_glendale_cove_BC = {
+					wakashan = "Gayuxw" }
 				b_hardwicke_island_BC = {}
 				b_phillips_arm_BC = {
-					shuswap = "Hwihawi"
+					wakashan = "Hwihawi"
 				}
 				b_homathko_river_BC = {}
 				b_moh_creek_BC = {}
@@ -396,6 +484,12 @@ e_cascadia = {
 		capital = 567 #Cariboo
 		
 		haida = "Ts'aagws Xaat'aay"	#Interior peoples
+		canuck = "The Interior"
+		shuswap = "Xiyúyem Secwepemcstín" #Greater Homeland of the Shuswap
+		wakashan = "Tla'qit'at" #Nuu-chah-nulth for Interior people
+		dakelh = "Dene Keyoh" #Traditional territory of the Dene
+		ktunaxa = "Amak" #Country, earth, ground.
+		
 		
 		mormon = 20
 		raven_tales_reformed = 500
@@ -404,10 +498,13 @@ e_cascadia = {
 			color = { 20 222 130 }
 			color2 = { 255 255 255 }
 			
-			culture = canuck
+			culture = shuswap
 			
 			haida = "K'agdáahl" #Flat, open, berry-winnowing basket or plaque
 			canuck = "The Cariboo"
+			shuswap = "Nekéct" #forest, thicket
+			dakelh = "Nda Ts'un" #towards the south
+			ktunaxa = "Ka'ipu" #transliteration
 			
 			capital = 567 #Cariboo
 			
@@ -417,11 +514,15 @@ e_cascadia = {
 				
 				haida = "Gúul"	#gold
 				shuswap = "Texelc"
+				wakashan = "Texelc"
+				dakelh = "Texelc"
+				ktunaxa = "Texelc"
 				
 				b_williams_lake_BC = {}
 				b_100_mile_house_BC = {}
 				b_lac_la_hache_BC = {}
-				b_150_mile_house_BC = {}
+				b_150_mile_house_BC = {
+					shuswap = "Llexwéusem" }
 				b_horsefly_BC = {}
 				b_alkali_lake_BC = {}
 				b_hanceville_BC = {}
@@ -436,6 +537,9 @@ e_cascadia = {
 				
 				haida = "Sahlguda" #Barbecue
 				shuswap = "Tsilhqot'in"
+				wakashan = "Tsilhqot'in"
+				dakelh = "Tsilhqot'in"
+				ktunaxa = "Tsilhqot'in"
 				
 				b_alexis_creek_BC = {}
 				b_nemaiah_BC = {}
@@ -450,9 +554,14 @@ e_cascadia = {
 				color = { 229 15 8 }
 				color2 = { 6 112 223 }
 				
-				haida = "Gyahgdáang"	#GYoung spruce trees growing thickly together
+				haida = "Gyahgdáang"	#Young spruce trees growing thickly together
+				shuswap = "T'kemlups"
+				wakashan = "Nlaka'pamux"
+				dakelh = "Nlaka'pamux"
+				ktunaxa = "Nlaka'pamux"
 				
-				b_kamloops_BC = {}
+				b_kamloops_BC = {
+					shuswap = "T'kemlups" }
 				b_merritt_BC = {}
 				b_logan_lake_BC = {}
 				b_lower_nicola_BC = {}
@@ -466,6 +575,9 @@ e_cascadia = {
 				
 				haida = "Kwaa" #rock, stone, pebble, boulder
 				shuswap = "Simpcw"
+				wakashan = "Simpcw"
+				dakelh = "Simpcw"
+				ktunaxa = "Simpcw"
 				
 				b_barriere_BC = {}
 				b_clearwater_BC = {}
@@ -485,10 +597,15 @@ e_cascadia = {
 				
 				haida = "K'uhlgwáasgyaan" #trail, portage across to the other side of something
 				shuswap = "Stuctuws"
+				wakashan = "Stuctuws"
+				dakelh = "Stuctuws"
+				ktunaxa = "Stuctuws"
 				
 				b_cache_creek_BC = {}
-				b_lillooet_BC = {}
-				b_clinton_BC = {}
+				b_lillooet_BC = {
+					shuswap = Stét'lemcw}
+				b_clinton_BC = {
+					shuswap = "Pelltíqt" }
 				b_ashcroft_BC = {}
 				b_spences_bridge_BC = {}
 				b_savona_BC = {}
@@ -504,10 +621,14 @@ e_cascadia = {
 			
 			haida = "Kiigaay"	#The old people
 			canuck = "The Kootenays"
+			shuswap = "Ktunaxa"
+			wakashan = "Ktunaxa"
+			dakelh = "Tl'ada" #Atop the hill
+			ktunaxa = "Mits'qaqas" #Upper Columbia River
 			
 			capital = 502 #Kootenay
 			
-			culture = canuck
+			culture = ktunaxa
 			
 			c_koocanusa = {
 				color = { 0 153 0 }
@@ -515,10 +636,14 @@ e_cascadia = {
 				
 				haida = "Sdlagw"	#River otter
 				shuswap = "Akisqnuk"
+				wakashan = "Akisqnuk"
+				dakelh = "Akisqnuk"
+				ktunaxa = "Akisqnuk"
 				
 				b_cranbrook_BC = {}
 				b_eureka_MT = {}
-				b_fernie_BC = {}
+				b_fernie_BC = {
+					ktunaxa = "Tsaqahak"}
 				b_invermere_BC = {}
 				b_radium_hot_springs_BC = {}
 				b_fort_steele_BC = {}
@@ -531,10 +656,15 @@ e_cascadia = {
 				color2 = { 182 182 182 }
 				
 				haida = "Tlat'a'áaw"	#mountain
-				shuswap = "Faknuqshuk"
+				shuswap = "Kenpes'qt"
+				wakashan = "Kenpes'qt"
+				dakelh = "Kenpes'qt"
+				ktunaxa = "Aknuqtluk"
 				
-				b_revelstoke_BC = {}
-				b_golden_BC = {}
+				b_revelstoke_BC = {
+					ktunaxa = "Ktunwa Kanmituk"}
+				b_golden_BC = {
+					ktunaxa = "Aknuktluk"}
 				b_field_BC = {}
 				b_mica_creek_BC = {}
 				b_canyon_hot_springs_BC = {}
@@ -542,7 +672,8 @@ e_cascadia = {
 				b_parson_BC = {}
 				b_blaeberry_BC = {}
 				b_elkford_BC = {}
-				b_sparwood_BC = {}
+				b_sparwood_BC = {
+					ktunaxa = "Kaqawakanmituqnik" }
 				b_crowsnest_AB = {}
 				b_yoho_BC = {}
 				b_forde_BC = {}
@@ -553,14 +684,19 @@ e_cascadia = {
 				
 				haida = "Xángk'a" #mountain face, previously Hlats'uxgaay, Northern Lights
 				shuswap = "Yaqan Nukiy"
+				wakashan = "Yaqan Nukiy"
+				dakelh = "Yaqan Nukiy"
+				ktunaxa = "Yaqan Nukiy"
 				
 				b_nelson_BC = {}
-				b_creston_BC = {}
+				b_creston_BC = {
+					ktunaxa = "Yaqannuki" }
 				b_balfour_BC = {}
 				b_kaslo_BC = {}
 				b_riondel_BC = {}
 				b_argenta_BC = {}
-				b_bonners_ferry_ID = {}
+				b_bonners_ferry_ID = {
+					ktunaxa = "Kaq'tlahatl"}
 				b_gray_creek_BC = {}
 				b_crawford_bay = {}
 				b_wynndel_BC = {}
@@ -571,6 +707,9 @@ e_cascadia = {
 				
 				haida = "Kaj T'anuwáay" #crowsnest (metaphorical, referring to messy hair)
 				shuswap = "Sinixt"
+				wakashan = "Sinixt"
+				dakelh = "Sinixt"
+				ktunaxa = "Sinixt"
 				
 				b_trail_BC = {}
 				b_grand_forks_BC = {}
@@ -590,9 +729,13 @@ e_cascadia = {
 				
 				haida = "Kíid Hlgwáay"	#Spruce Sapling
 				shuswap = "Neqo'sp"
+				wakashan = "Neqo'sp"
+				dakelh = "Neqo'sp"
+				ktunaxa = "Tsatlnu'akuq'nuk"
 				
 				b_castlegar_BC = {}
-				b_nakusp_BC = {}
+				b_nakusp_BC = {
+					ktunaxa = "Tsatlnu'akuq'nuk" }
 				b_new_denver_BC = {}
 				b_slocan_BC = {}
 				b_crescent_valley_BC = {}
@@ -613,14 +756,22 @@ e_cascadia = {
 			capital = 570 #Kelowna
 			
 			haida = "Súu Káahlii" #lake valley
+			canuck = "The Okanagan"
 			shuswap = "Sukwnaqinx"
+			wakashan = "Sukwnaqinx"
+			dakelh = "Sukwnaqinx"
+			ktunaxa = "Sukwnaqinx"
 			
 			c_similkameen = {
 				color = { 144 210 50 }
 				color2 = { 0 144 48 }
 				
 				haida = "K'án" #berry
+				canuck = "The Similkameen"
 				shuswap = "Smelqmix"
+				wakashan = "Smelqmix"
+				dakelh = "Smelqmix"
+				ktunaxa = "Smelqmix"
 				
 				b_princeton_BC = {}
 				b_keremos_BC = {}
@@ -639,7 +790,11 @@ e_cascadia = {
 				color2 = { 3 130 56 }
 				
 				haida = "Sk'a'áangwaay"	#basket-like cylindrical fish trap, previously Tl'áadaan - Canyon/Gorge
+				canuck = "The Shuswap"
 				shuswap = "Secwepemc"
+				wakashan = "Secwepemc"
+				dakelh = "Secwepemc"
+				ktunaxa = "Ktlitqatwumtlat"
 				
 				b_vernon_BC = {}
 				b_salmon_arm_BC = {}
@@ -662,6 +817,9 @@ e_cascadia = {
 				
 				haida = "Hlk'unáanwaay"	#brush
 				shuswap = "Sukwnaqinx"
+				wakashan = "Sukwnaqinx"
+				dakelh = "Sukwnaqinx"
+				ktunaxa = "Sukwnaqinx"
 				
 				b_kelowna_BC = {}
 				b_penticton_BC = {}
@@ -679,6 +837,10 @@ e_cascadia = {
 				color2 = { 40 93 72 }
 				
 				haida = "Sdalaay"	#steep slope, cliff
+				shuswap = "Wenatchi"
+				wakashan = "Wenatchi"
+				dakelh = "Wenatchi"
+				ktunaxa = "Wenatchi"
 				
 				b_sunnyslope_WA = {}
 				b_chelan_WA = {}
@@ -698,7 +860,10 @@ e_cascadia = {
 			capital = 551 #Fjordland
 		
 			haida = "Kiladáay" #the Tsimshian people
-			shuswap = "Haisla"
+			shuswap = "Nuxalk"
+			wakashan = "Haisla"
+			dakelh = "'Onyaz Ts'e" #On the other side
+			ktunaxa = "Apakitlhak" #inlet
 
 			c_fjordland = {
 				color = { 115 160 219 }
@@ -706,6 +871,9 @@ e_cascadia = {
 				
 				haida = "Gidgáahlaas" #southern Tsimshian people
 				shuswap = "Heiltsuk"
+				wakashan = "Heiltsuk"
+				dakelh = "Heiltsuk"
+				ktunaxa = "Heiltsuk"
 			
 				b_bella_bella_BC = {
 					haida = "Tlajáng"
@@ -724,6 +892,9 @@ e_cascadia = {
 				
 				haida = "Tlajáng"
 				shuswap = "Nuxalk"
+				wakashan = "Oowekyala"
+				dakelh = "Oowekyala"
+				ktunaxa = "Nuxalk"
 				
 				b_bella_coola_BC = {
 					haida = "Nuxalk"
@@ -732,6 +903,7 @@ e_cascadia = {
 				b_rivers_inlet_BC = {
 					haida = "Wannuck"
 					shuswap = "Wannuck"
+					wakashan = "Galdala"
 				}
 				b_hagensborg_BC = {}
 				b_namu_BC = {}
@@ -754,6 +926,9 @@ e_cascadia = {
 				
 				haida = "Gaw" #Inlet
 				shuswap = "Kitamaat"
+				wakashan = "Haisla"
+				dakelh = "'Utna"
+				ktunaxa = "Haisla"
 				
 				b_kitimat_BC = {}
 				b_terrace_BC = {}
@@ -771,11 +946,15 @@ e_cascadia = {
 			color = { 55 157 160 }
 			color2 = { 255 255 255 }
 			
-			culture = canuck
+			culture = dakelh
 			
 			capital = 682 #Prince George
 			
 			haida = "Ts'aagws Xaat'áay" #interior people, salish, also used to describe k_lincoln
+			canuck = "The Northern Interior" #if too boring and descriptive, this can be removed
+			shuswap = "T'ki'ékst" #north wind
+			dakelh = "Dakelh Keyoh"
+			ktunaxa = "Amin'ika" #transliteration
 			
 			c_prince_george = {
 				color = { 162 133 33 }
@@ -783,6 +962,9 @@ e_cascadia = {
 				
 				haida = "Jáajii" #Snowshoes
 				shuswap = "Dakelh"
+				wakashan = "Dakelh"
+				dakelh = "Dakelh"
+				ktunaxa = "Dakelh"
 				
 				b_prince_george_BC = {}
 				b_quesnel_BC = {}
@@ -802,7 +984,10 @@ e_cascadia = {
 				
 				haida = "Gándl Kaj" #head of a river
 				shuswap = "Texqakallt"
-								
+				wakashan = "Texqakallt"
+				dakelh = "Texqakallt"
+				ktunaxa = "Texqakallt"
+				
 				b_valemount_BC = {}
 				b_mcbride_BC = {}
 				b_upper_fraser_BC = {}
@@ -821,6 +1006,9 @@ e_cascadia = {
 				
 				haida = "Gándlaadaa Xaadas" #baptized people
 				shuswap = "Netja Koh"
+				wakashan = "Netja Koh"
+				dakelh = "Necha-Koh"
+				ktunaxa = "Netja Koh"
 				
 				b_vanderhoof_BC = {}
 				b_fraser_lake_BC = {}
@@ -840,6 +1028,9 @@ e_cascadia = {
 				
 				haida = "Hlats'uxgáay" #northern lights
 				shuswap = "Wet'suwet'en"
+				wakashan = "Wet'suwet'en"
+				dakelh = "Wet'suwet'en"
+				ktunaxa = "Wet'suwet'en"
 				
 				b_smithers_BC = {}
 				b_telkwa_BC = {}
@@ -863,6 +1054,8 @@ e_cascadia = {
 		capital = 543 #Seattle
 		
 		haida = "Taagwaa"	#Down South
+		ktunaxa = "Siyatl"
+		
 		raven_tales_reformed = 1000
 		
 		d_north_jefferson = {
@@ -879,7 +1072,7 @@ e_cascadia = {
 				color = { 244 220 0 }
 				color2 = { 0 0 0 }
 				
-				haida = "Hlk'ungadaay"	#miner's root
+				haida = "hlk'ungadaay"	#miner's root
 				
 				b_grants_pass_OR = {}
 				b_merlin_OR = {}
@@ -893,7 +1086,7 @@ e_cascadia = {
 				color = { 210 170 98 }
 				color2 = { 25 60 28 }
 				
-				haida = "Hlkyeewjaa"	#the shade
+				haida = "hlkyeewjaa"	#the shade
 				
 				b_medford_OR = {}
 				b_phoenix_OR = {}
@@ -1184,7 +1377,7 @@ e_cascadia = {
 			color = { 108 157 50 }
 			color2 = { 255 195 19 }
 			
-			#culture = cascadian
+			#culture = canuck #used to be cascadian, anyone know why?
 			
 			capital = 541 #Capitol
 			
@@ -1263,11 +1456,12 @@ e_cascadia = {
 			color = { 0 131 134 }
 			color2 = { 255 255 255 }
 			
-			#culture = cascadian
+			#culture = canuck #used to be cascadian, anyone know why?
 			
 			capital = 543 #Seattle
 			
 			haida = "Gii Tl'agang"	#anchor a fleet of boats
+			ktunaxa = "Siyatl"
 			
 			c_rainier = {
 				color = { 152 203 254 }
@@ -1294,10 +1488,13 @@ e_cascadia = {
 				
 				haida = "K'iida"	#store up
 				motowner = "Morocco"
+				ktunaxa = "Siyatl"
+				
 				holy_site = nousthreskeia #Lenin statue
 				
 				b_seattle_WA = {
 					motowner = "Morocco"
+					ktunaxa = "Siyatl"
 				}
 				b_bellevue_WA = {}
 				b_redmond_WA = {}
@@ -1345,6 +1542,7 @@ e_cascadia = {
 		capital = 505 #Spokane Valley
 		
 		haida = "Ts'aagws Xaat'aay"	#The interior people, salish
+		ktunaxa = "Spuq'in" #Spokane
 		
 		d_colville = {
 			color = { 247 184 0 }
@@ -1352,9 +1550,10 @@ e_cascadia = {
 			
 			capital = 505 #Spokane Valley
 			
-			culture = shuswap
+			culture = ktunaxa
 			
 			haida = "Git'awyaas" #the Salish language
+			ktunaxa = "Xapqtlinik'"
 			
 			raven_tales_reformed = 500
 			
@@ -1363,13 +1562,16 @@ e_cascadia = {
 				color2 = { 96 50 17 }
 				
 				haida = "K'aayhlt'aa Sk'awíi"	#falling star
+				ktunaxa = "Kamanqukutl"
 				
-				b_sandpoint_ID = {}
+				b_sandpoint_ID = {
+					ktunaxa = "Kamanqukutl"}
 				b_priest_river_ID = {}
 				b_newport_WA = {}
 				b_dover_ID = {}
 				b_ponderay_ID = {}
-				b_kootenai_ID = {}
+				b_kootenai_ID = {
+					ktunaxa = "A'kaxapqtli" }
 				b_schweitzer_ID = {}
 			}
 			c_pend_oreille = {
@@ -1377,12 +1579,14 @@ e_cascadia = {
 				color2 = { 255 153 64 }
 				
 				haida = "Ts'angaay"	#beaver
+				ktunaxa = "Kanuq'tlatlam"
 				
 				b_chewelah_WA = {}
 				b_kettle_falls_WA = {}
 				b_wellpinit_WA = {}
 				b_ione_WA = {}
-				b_usk_WA = {}
+				b_usk_WA = {
+					ktunaxa = "Aq'anq'una'wuk" }
 				b_addy_WA = {}
 				b_coleville_WA = {}
 			}
@@ -1391,8 +1595,10 @@ e_cascadia = {
 				color2 = { 0 132 202 }
 				
 				haida = "Laam Naay"	#saloon, bar
+				ktunaxa = "Spuq'in"
 				
-				b_spokane_WA = {}
+				b_spokane_WA = {
+					ktunaxa = "Spuq'in" }
 				b_mead_WA = {}
 				b_colbert_WA = {}
 				b_cheney_WA = {}
@@ -1405,6 +1611,7 @@ e_cascadia = {
 				color2 = { 10 16 70 }
 				
 				haida = "Taw'laa"	#good friends
+				ktunaxa = "Xapqtlinik'"
 				
 				b_coulee_dam_WA = {}
 				b_disautel_WA = {}
@@ -1673,10 +1880,13 @@ e_cascadia = {
 				color2 = { 129 26 30 }
 				
 				haida = "Tl'ahl"	#mallet
+				ktunaxa = Kqaskanmituk"
 				
-				b_kalispell_MT = {}
+				b_kalispell_MT = {
+					ktunaxa = "Kqaya Qawa Ktlu'nam"}
 				b_poison_MT = {}
-				b_ronan_MT = {}
+				b_ronan_MT = {
+					ktunaxa = "Kwitlq'nuk"}
 				b_evergreen_MT = {}
 				b_big_arm_MT = {}
 				b_whitefish_MT = {}
@@ -1687,9 +1897,12 @@ e_cascadia = {
 				color2 = { 152 215 187 }
 				
 				haida = "Tajuu"	#windy
+				ktunaxa = "Tuhutlnana"
 				
-				b_missoula_MT = {}
-				b_hamilton_MT = {}
+				b_missoula_MT = {
+					ktunaxa = "Tuhutlnana" }
+				b_hamilton_MT = {
+					ktunaxa = "Mukwuk" }
 				b_lolo_MT = {}
 				b_darby_MT = {}
 				b_corvallis_MT = {}

--- a/After the End Fan Fork/common/landed_titles/thunderland.txt
+++ b/After the End Fan Fork/common/landed_titles/thunderland.txt
@@ -338,7 +338,8 @@ e_thunderland = {
 				b_cardston_AB = {}
 				b_magrath_AB = {}
 				b_cut_bank_MT = {}
-				b_browning_MT = {}
+				b_browning_MT = {
+					ktunaxa = "Tlawat'inak"}
 				b_glenwood_AB = {}
 				b_hill_spring_AB = {}
 				b_aetna_AB = {}
@@ -370,7 +371,10 @@ e_thunderland = {
 				color = { 42 94 167 }
 				color2 = { 141 94 47 }
 				
-				b_helena_MT = {}
+				ktunaxa = "K'qtlaqaq'yuqunuk"
+				
+				b_helena_MT = {
+					ktunaxa = "K'qtlaqaq'yuqunuk"}
 				b_bozeman_MT = {}
 				b_gellatin_MT = {}
 				b_belgrade_MT = {}
@@ -394,9 +398,13 @@ e_thunderland = {
 				color = { 132 151 57 }
 				color2 = { 134 137 8 }
 				
-				b_swan_lake_MT = {}
+				ktunaxa = "Nasuq'ut'"
+				
+				b_swan_lake_MT = {
+					ktunaxa = "Nasuq'ut'" }
 				b_seeley_lake_MT = {}
-				b_bigfork_MT = {}
+				b_bigfork_MT = {
+					ktunaxa = "Nasuq'ut' Kakanmituk" }
 				b_ovando_MT = {}
 				b_condon_MT = {}
 				b_clearwater_MT = {}
@@ -635,7 +643,8 @@ e_thunderland = {
 
 				haida = "Kat'a'eehl"	#climb down, descend
 				
-				b_calgary_AB = {}
+				b_calgary_AB = {
+					ktunaxa = "Aknuqtaptsik'" }
 				b_bragg_creek_AB = {}
 				b_priddis_AB = {}
 				b_okotoks_AB = {}


### PR DESCRIPTION
Added cultural names for counties, duchies and kingdoms in the Northwest. Changes affect cascadia.txt and thunderland.txt only.