### PR TITLE
New dynasties from Canada Expanded

### DIFF
--- a/After the End Fan Fork/common/dynasties/after_the_end_dynasties.txt
+++ b/After the End Fan Fork/common/dynasties/after_the_end_dynasties.txt
@@ -41,7 +41,7 @@
 1001037 = { name="Baker" culture=newfie }
 1001038 = { name="Fifield" culture=newfie }
 1001039 = { name="Dyke" culture=newfie }
-1001040 = { name="Hann" culture=newfie }
+1001040 = { name="Quirk" culture=newfie }
 1001041 = { name="Kent" culture=newfie }
 1001042 = { name="Lacey" culture=newfie }
 1001043 = { name="Spracklin" culture=newfie }
@@ -52,7 +52,56 @@
 1001048 = { name="March" culture=newfie }
 1001049 = { name="Baird" culture=newfie }
 1001050 = { name="Sweetapple" culture=newfie }
-1001051 = { name="Fay" culture=newfie }
+1001051 = { name="Fay" culture=newfie }
+1001052 = { name="Horwood" culture=newfie }
+1001053 = { name="O'Mara" culture=newfie }
+1001054 = { name="Scammell" culture=newfie }
+1001055 = { name="Chaffey" culture=newfie }
+1001056 = { name="Mitchelmore" culture=newfie }
+1001057 = { name="Greeley" culture=newfie }
+1001058 = { name="Whiteway" culture=newfie }
+1001059 = { name="Crocker" culture=newfie }
+1001060 = { name="Dunderdale" culture=newfie }
+1001061 = { name="Gambin" culture=newfie }
+1001062 = { name="O'Driscoll" culture=newfie }
+1001063 = { name="Stoodley" culture=newfie }
+1001064 = { name="Ball" culture=newfie }
+1001065 = { name="Troake" culture=newfie }
+1001066 = { name="Fogo" culture=newfie }
+1001067 = { name="Noseworthy" culture=newfie }
+1001068 = { name="Efford" culture=newfie }
+1001069 = { name="Younghusband" culture=newfie }
+1001070 = { name="Mifflin" culture=newfie }
+1001071 = { name="Lash" culture=newfie }
+1001072 = { name="Ricketts" culture=newfie }
+1001073 = { name="Batchar" culture=newfie }
+1001074 = { name="Doyle" culture=newfie }
+1001075 = { name="Alderdice" culture=newfie }
+1001076 = { name="Molony" culture=newfie }
+1001077 = { name="Meagher" culture=newfie }
+1001078 = { name="Learning" culture=newfie }
+1001079 = { name="Druken" culture=newfie }
+1001080 = { name="Hawco" culture=newfie }
+1001081 = { name="Cloud" culture=newfie }
+1001082 = { name="Lundrigan" culture=newfie }
+1001083 = { name="Recontre" culture=newfie }
+1001084 = { name="Shott" culture=newfie }
+1001085 = { name="Kirwan" culture=newfie }
+1001086 = { name="Clowe" culture=newfie }
+1001087 = { name="Farwell" culture=newfie }
+1001088 = { name="Tibbs" culture=newfie }
+1001089 = { name="Seldom" culture=newfie }
+1001090 = { name="Cuper" culture=newfie }
+1001091 = { name="Hann" culture=newfie }
+1001092 = { name="Inkpen" culture=newfie }
+1001093 = { name="Lyver" culture=newfie }
+1001094 = { name="Squires" culture=newfie }
+1001095 = { name="Fizzard" culture=newfie }
+1001096 = { name="Grouchy" culture=newfie }
+1001097 = { name="Puddester" culture=newfie }
+1001098 = { name="Creates" culture=newfie }
+1001099 = { name="Varder" culture=newfie }
+1001100 = { name="Pittman" culture=newfie }
 
 1115000 = { name="Ostersen" culture=mixtec }
 1115001 = { name="Zne Yel" culture=mixtec }
@@ -496,7 +545,10 @@
 	} }1491004 = { name="Hois" culture=comanche }1491005 = { name="Ketatore" culture=comanche }1491006 = { name="Napwat Tu" culture=comanche }1491007 = { name="Titchahkaynah" culture=comanche }1491008 = { name="Nevaquaya" culture=comanche }1491009 = { name="Parker" culture=comanche }
 1491010 = { name="Penateka" culture=comanche }
 
-1491100 = { name="Ogala" culture=sioux }1491101 = { name="Glaglaheca" culture=sioux }1491102 = { name="Wakpokinyan" culture=sioux }1491103 = { name="Hokwoju" culture=sioux
+1491100 = { name="Ogala" culture=sioux }
+1491101 = { name="Glaglaheca" culture=sioux }
+1491102 = { name="Wakpokinyan" culture=sioux }
+1491103 = { name="Hokwoju" culture=sioux
 	coat_of_arms = {
 		religion = cetic
 		template = 0
@@ -508,8 +560,59 @@
 			color = 0
 			color = 0
 		}
-	} }1491104 = { name="Itazipcho" culture=sioux }1491105 = { name="Hungkpapha" culture=sioux }1491106 = { name="Wagleza-oin" culture=sioux }1491107 = { name="Oohenungpa" culture=sioux }1491108 = { name="Wicasa" culture=sioux }1491109 = { name="Hazipco" culture=sioux }1491110 = { name="Itazipco-hca" culture=sioux }1491111 = { name="Oiglapta" culture=sioux }1491112 = { name="Mnisala" culture=sioux }1491113 = { name="Ma-wahota" culture=sioux }1491114 = { name="Iyakoza" culture=sioux }1491115 = { name="Shawala" culture=sioux }1491116 = { name="Shiyolanka" culture=sioux }1491117 = { name="Wacheunpa" culture=sioux }1491118 = { name="Chokatowela" culture=sioux }1491119 = { name="Waleghaunwohan" culture=sioux }1491120 = { name="Nakhpakhpa" culture=sioux }1491121 = { name="Apewantanka" culture=sioux }1491122 = { name="Heova'ehe" culture=sioux }1491123 = { name="Ihanktonwan" culture=sioux }1491124 = { name="Sisapa" culture=sioux }1491125 = { name="Ingyang" culture=sioux }
-1491126 = { name="Húnkpapha" culture=sioux }
+	} }
+1491104 = { name="Itazipcho" culture=sioux }
+1491105 = { name="Hungkpapha" culture=sioux }
+1491106 = { name="Wagleza-oin" culture=sioux }
+1491107 = { name="Oohenungpa" culture=sioux }
+1491108 = { name="Wicasa" culture=sioux }
+1491109 = { name="Hazipco" culture=sioux }
+1491110 = { name="Itazipco-hca" culture=sioux }
+1491111 = { name="Oiglapta" culture=sioux }
+1491112 = { name="Mnisala" culture=sioux }
+1491113 = { name="Ma-wahota" culture=sioux }
+1491114 = { name="Iyakoza" culture=sioux }
+1491115 = { name="Shawala" culture=sioux }
+1491116 = { name="Shiyolanka" culture=sioux }
+1491117 = { name="Wacheunpa" culture=sioux }
+1491118 = { name="Chokatowela" culture=sioux }
+1491119 = { name="Waleghaunwohan" culture=sioux }
+1491120 = { name="Nakhpakhpa" culture=sioux }
+1491121 = { name="Apewantanka" culture=sioux }
+1491122 = { name="Heova'ehe" culture=sioux }
+1491123 = { name="Ihanktonwan" culture=sioux }
+1491124 = { name="Sisapa" culture=sioux }
+1491125 = { name="Ingyang" culture=sioux }
+1491126 = { name="Canhdada" culture=sioux }
+1491127 = { name="Aegitina" culture=sioux }
+1491128 = { name="Bizebina" culture=sioux }
+1491129 = { name="Chanhewinchasta" culture=sioux }
+1491130 = { name="Canknuhabi" culture=sioux }
+1491131 = { name="Hudesabina" culture=sioux }
+1491132 = { name="Ye Xa Yabine" culture=sioux }
+1491133 = { name="Henatonwaabina" culture=sioux }
+1491134 = { name="Huhumasmbi" culture=sioux }
+1491135 = { name="Indogahwincasta" culture=sioux }
+1491136 = { name="Ini'nau'mbi" culture=sioux }
+1491137 = { name="Icna'umbisa" culture=sioux }
+1491138 = { name="Iyethkabi" culture=sioux }
+1491139 = { name="Minisose Swnkcebe" culture=sioux }
+1491140 = { name="Osnibi" culture=sioux }
+1491141 = { name="Psamnéwi" culture=sioux }
+1491142 = { name="Sahiyaiyeskabi" culture=sioux }
+1491143 = { name="Tanzinapebina" culture=sioux }
+1491144 = { name="Unskaha" culture=sioux }
+1491145 = { name="Wokpanbi" culture=sioux }
+1491146 = { name="Waziyamwincasta" culture=sioux }
+1491147 = { name="Watopachnato" culture=sioux }
+1491148 = { name="Tokanbi" culture=sioux }
+1491149 = { name="Waci'azihyabin" culture=sioux }
+1491150 = { name="Ceghakin" culture=sioux }
+1491151 = { name="Ostikwan" culture=sioux }
+1491152 = { name="Thithunwan" culture=sioux }
+1491153 = { name="Kaksizahanska" culture=sioux }
+1491154 = { name="Bdehdakinyan" culture=sioux }
+1491155 = { name="Sicangu" culture=sioux }
 
 1491200 = { name="Ridge" culture=cherokee }1491201 = { name="Boudinot" culture=cherokee
 	coat_of_arms = {
@@ -546,7 +649,8 @@
 
 1491300 = { name="Menewa" culture=muscogee }1491301 = { name="Chebona" culture=muscogee }1491302 = { name="Osceola" culture=muscogee }1491303 = { name="Chitto" culture=muscogee }1491304 = { name="Hasse Ola" culture=muscogee }1491305 = { name="Hopoethe" culture=muscogee }1491306 = { name="Talof Harjo" culture=muscogee }1491307 = { name="Hothlepoya" culture=muscogee }1491308 = { name="Lumhe Chati" culture=muscogee }1491309 = { name="Tustenuggee" culture=muscogee }1491310 = { name="Homathlemico" culture=muscogee }1491311 = { name="Cowaya" culture=muscogee }1491312 = { name="Yaholo" culture=muscogee }
 
-1491400 = { name="Ozawanimke" culture=algonquin }1491401 = { name="Amikons" culture=algonquin
+1491400 = { name="Ozawanimke" culture=algonquin }
+1491401 = { name="Amikons" culture=algonquin
 	coat_of_arms = {
 		religion = cetic
 		template = 0
@@ -558,9 +662,207 @@
 			color = 0
 			color = 0
 		}
-	} }1491402 = { name="Tenniscoe" culture=algonquin }1491403 = { name="Meness" culture=algonquin }1491404 = { name="Whiteduck" culture=algonquin }1491405 = { name="Sarazin" culture=algonquin }1491406 = { name="Commanda" culture=algonquin }1491407 = { name="Cota" culture=algonquin }1491408 = { name="Odjick" culture=algonquin }1491409 = { name="Cayer" culture=algonquin }1491410 = { name="Brazeau" culture=algonquin }1491411 = { name="Tremblay" culture=algonquin }1491412 = { name="de Pikogan" culture=algonquin }1491413 = { name="Vollant" culture=algonquin }
+	} }
+1491402 = { name="Tenniscoe" culture=algonquin }
+1491403 = { name="Meness" culture=algonquin }
+1491404 = { name="Whiteduck" culture=algonquin }
+1491405 = { name="Sarazin" culture=algonquin }
+1491406 = { name="Commanda" culture=algonquin }
+1491407 = { name="Cota" culture=algonquin }
+1491408 = { name="Odjick" culture=algonquin }
+1491409 = { name="Cayer" culture=algonquin }
+1491410 = { name="Brazeau" culture=algonquin }
+1491411 = { name="Tremblay" culture=algonquin }
+1491412 = { name="de Pikogan" culture=algonquin }
+1491413 = { name="Vollant" culture=algonquin }
+1491414 = { name="Benoit" culture=algonquin }
+1491415 = { name="Lavalley" culture=algonquin }
+1491416 = { name="Brascoupe" culture=algonquin }
+1491417 = { name="Pakinawatik" culture=algonquin }
+1491418 = { name="Polson" culture=algonquin }
+1491419 = { name="Newashish" culture=algonquin }
+1491420 = { name="Redeagle" culture=algonquin }
+1491421 = { name="Wahgoshig" culture=algonquin }
+1491422 = { name="Nowegejick" culture=algonquin }
+1491423 = { name="Kohoko" culture=algonquin }
+1491424 = { name="Twoaxe" culture=algonquin }
+1491425 = { name="Timmerman" culture=algonquin }
+1491426 = { name="Frawley" culture=algonquin }
+1491427 = { name="Miskouaha" culture=algonquin }
+1491428 = { name="Simosagigan" culture=algonquin }
+1491429 = { name="Yroquetto" culture=algonquin }
+1491430 = { name="Couc" culture=algonquin }
+1491431 = { name="Wusamequin" culture=algonquin }
+1491432 = { name="Winnecomac" culture=algonquin }
+1491433 = { name="Moweaqua" culture=algonquin }
+1491434 = { name="Tarhe" culture=algonquin }
+1491435 = { name="Wyandanch" culture=algonquin }
+1491436 = { name="Jocko" culture=algonquin }
+1491437 = { name="Buckshot" culture=algonquin }
+1491438 = { name="Couvarte" culture=algonquin }
+1491439 = { name="Tchanana" culture=algonquin }
+1491440 = { name="Maheux" culture=algonquin }
+1491441 = { name="Pezudewatch" culture=algonquin }
+1491442 = { name="Beakabech" culture=algonquin }
+1491443 = { name="Ceakabec" culture=algonquin }
+1491444 = { name="Ojuske" culture=algonquin }
+1491445 = { name="Okwisiwan" culture=algonquin }
+1491446 = { name="Wabanonik" culture=algonquin }
+1491447 = { name="Paskisidjigang" culture=algonquin }
+1491448 = { name="Nemastoksan" culture=algonquin }
+1491449 = { name="Mokotagan" culture=algonquin }
+1491450 = { name="Meranda" culture=algonquin }
+1491451 = { name="Endogwan" culture=algonquin }
+1491452 = { name="Petremond" culture=algonquin }
+1491453 = { name="Malgourgik" culture=algonquin }
+1491454 = { name="Magineigripak" culture=algonquin }
+1491455 = { name="Rupablase" culture=algonquin }
+1491456 = { name="Ampuchue" culture=algonquin }
+1491457 = { name="Kielaprah" culture=algonquin }
+1491458 = { name="Nichanny" culture=algonquin }
+1491459 = { name="Ogenah" culture=algonquin }
+1491460 = { name="Sherbatt" culture=algonquin }
+1491461 = { name="Wimistegosh" culture=algonquin }
+1491462 = { name="Wineokons" culture=algonquin }
+1491463 = { name="Nynvaswi" culture=algonquin }
+1491464 = { name="Djidjic" culture=algonquin }
+1491465 = { name="Antwenens" culture=algonquin }
+1491466 = { name="Ikiwesi" culture=algonquin }
+1491467 = { name="Kwakso" culture=algonquin }
+1491468 = { name="Ukiwenshi" culture=algonquin }
+1491469 = { name="Mack" culture=algonquin }
+1491470 = { name="Wettenasseus" culture=algonquin }
+1491471 = { name="Thivierge" culture=algonquin }
+1491472 = { name="McNobie" culture=algonquin }
+1491473 = { name="Goracheck" culture=algonquin }
+1491474 = { name="Jamicheway" culture=algonquin }
+1491475 = { name="Corinthe" culture=algonquin }
+1491476 = { name="Sakoket" culture=algonquin }
+1491477 = { name="Arerhon" culture=algonquin }
+1491478 = { name="Welawaseis" culture=algonquin }
+1491479 = { name="Feneska" culture=algonquin }
+1491480 = { name="Stoqua" culture=algonquin }
+1491481 = { name="Andanawas" culture=algonquin }
+1491482 = { name="Nefonnewish" culture=algonquin }
+1491483 = { name="Onaquelle" culture=algonquin }
+1491484 = { name="Dloniontes" culture=algonquin }
+1491485 = { name="Arissakexka" culture=algonquin }
+1491486 = { name="Emimitegnesh" culture=algonquin }
+1491487 = { name="Chaganache" culture=algonquin }
+1491488 = { name="Schodjic" culture=algonquin }
+1491489 = { name="Tjinagasi" culture=algonquin }
+1491490 = { name="Welmiscorse" culture=algonquin }
+1491491 = { name="Sheshedrie" culture=algonquin }
+1491492 = { name="Welmiscorse" culture=algonquin }
+1491493 = { name="Carnasnace" culture=algonquin }
+1491494 = { name="Welmiscorse" culture=algonquin }
+1491495 = { name="Corne-Lagoes" culture=algonquin }
+1491496 = { name="Siagosi" culture=algonquin }
+1491497 = { name="Abohodjeri" culture=algonquin }
+1491498 = { name="Wabemux" culture=algonquin }
+1491499 = { name="Jacksuze" culture=algonquin }
 
-1491500 = { name="Nekesh" culture=ojibwe }1491501 = { name="Asham" culture=ojibwe }1491502 = { name="Oshie" culture=ojibwe }1491503 = { name="DesJarlait" culture=ojibwe }1491504 = { name="Secola" culture=ojibwe }1491505 = { name="Pegahmagabow" culture=ojibwe }1491506 = { name="Shawanda" culture=ojibwe }1491507 = { name="Nawakamigok" culture=ojibwe }1491508 = { name="Davieux" culture=ojibwe }1491509 = { name="Syrette" culture=ojibwe }1491510 = { name="Angeconeb" culture=ojibwe }1491511 = { name="Nipigon" culture=ojibwe }
+1491500 = { name="Nekesh" culture=ojibwe }
+1491501 = { name="Asham" culture=ojibwe }
+1491502 = { name="Oshie" culture=ojibwe }
+1491503 = { name="DesJarlait" culture=ojibwe }
+1491504 = { name="Secola" culture=ojibwe }
+1491505 = { name="Pegahmagabow" culture=ojibwe }
+1491506 = { name="Shawanda" culture=ojibwe }
+1491507 = { name="Nawakamigok" culture=ojibwe }
+1491508 = { name="Davieux" culture=ojibwe }
+1491509 = { name="Syrette" culture=ojibwe }
+1491510 = { name="Angeconeb" culture=ojibwe }
+1491511 = { name="Nipigon" culture=ojibwe }
+1491512 = { name="Prince" culture=ojibwe }
+1491513 = { name="Lumsden" culture=ojibwe }
+1491514 = { name="Boucha" culture=ojibwe }
+1491515 = { name="Erdrich" culture=ojibwe }
+1491516 = { name="Matoush" culture=ojibwe }
+1491517 = { name="Assikinack" culture=ojibwe }
+1491518 = { name="Plamondon" culture=ojibwe }
+1491519 = { name="Fairbrother" culture=ojibwe }
+1491520 = { name="Sargent" culture=ojibwe }
+1491521 = { name="Copway" culture=ojibwe }
+1491522 = { name="Morrisseau" culture=ojibwe }
+1491523 = { name="Youngfox" culture=ojibwe }
+1491524 = { name="Naponse" culture=ojibwe }
+1491525 = { name="Vizenor" culture=ojibwe }
+1491526 = { name="Chrisjohn" culture=ojibwe }
+1491527 = { name="Grosbeck" culture=ojibwe }
+1491528 = { name="Sturgeon" culture=ojibwe }
+1491529 = { name="Tegosh" culture=ojibwe }
+1491530 = { name="Nadjiwon" culture=ojibwe }
+1491531 = { name="Waybooslsiki" culture=ojibwe }
+1491532 = { name="Debakouang" culture=ojibwe }
+1491533 = { name="Magatanah" culture=ojibwe }
+1491534 = { name="Ininway" culture=ojibwe }
+1491535 = { name="Lapouche" culture=ojibwe }
+1491536 = { name="M'Chigeeng" culture=ojibwe }
+1491537 = { name="Ogoki" culture=ojibwe }
+1491538 = { name="Mandamin" culture=ojibwe }
+1491539 = { name="Kagige" culture=ojibwe }
+1491540 = { name="Okahaishkook" culture=ojibwe }
+1491541 = { name="Oombash" culture=ojibwe }
+1491542 = { name="Shakakeesic" culture=ojibwe }
+1491543 = { name="Friday" culture=ojibwe }
+1491544 = { name="Wenjack" culture=ojibwe }
+1491545 = { name="Towedo" culture=ojibwe }
+1491546 = { name="Atlookan" culture=ojibwe }
+1491547 = { name="Matasawagon" culture=ojibwe }
+1491548 = { name="O'Nabigon" culture=ojibwe }
+1491549 = { name="Aroland" culture=ojibwe }
+1491550 = { name="Echum" culture=ojibwe }
+1491551 = { name="Gustufson" culture=ojibwe }
+1491552 = { name="Kwandibens" culture=ojibwe }
+1491553 = { name="Matchiendagos" culture=ojibwe }
+1491554 = { name="Sheguiandah" culture=ojibwe }
+1491555 = { name="Quarrington" culture=ojibwe }
+1491556 = { name="Noganosh" culture=ojibwe }
+1491557 = { name="Ogemawahj" culture=ojibwe }
+1491558 = { name="Mnjikaning" culture=ojibwe }
+1491559 = { name="Milliken" culture=ojibwe }
+1491560 = { name="Bressette" culture=ojibwe }
+1491561 = { name="Kahgegwagebow" culture=ojibwe }
+1491562 = { name="Onaiwah" culture=ojibwe }
+1491563 = { name="Wetamore" culture=ojibwe }
+1491564 = { name="Qunnoune" culture=ojibwe }
+1491565 = { name="Aan'aawenh" culture=ojibwe }
+1491566 = { name="Chequamegon" culture=ojibwe }
+1491567 = { name="Mazinaw" culture=ojibwe }
+1491568 = { name="Aamjiwnaang" culture=ojibwe }
+1491569 = { name="Leech" culture=ojibwe }
+1491570 = { name="Ontonagon" culture=ojibwe }
+1491571 = { name="Chatkana" culture=ojibwe }
+1491572 = { name="Roksiduka" culture=ojibwe }
+1491573 = { name="Hukaha" culture=ojibwe }
+1491574 = { name="Wiwaikeejick" culture=ojibwe }
+1491575 = { name="Kabaiasaka" culture=ojibwe }
+1491576 = { name="Agaakamook" culture=ojibwe }
+1491577 = { name="Wancouth" culture=ojibwe }
+1491578 = { name="Nadjaway" culture=ojibwe }
+1491579 = { name="Lewegshig" culture=ojibwe }
+1491580 = { name="Vanevery" culture=ojibwe }
+1491581 = { name="Bauchamp" culture=ojibwe }
+1491582 = { name="Egbedin" culture=ojibwe }
+1491583 = { name="Asawewinem" culture=ojibwe }
+1491584 = { name="Escanaget" culture=ojibwe }
+1491585 = { name="Astakastie" culture=ojibwe }
+1491586 = { name="Habigijig" culture=ojibwe }
+1491587 = { name="Yellowgill" culture=ojibwe }
+1491588 = { name="Wanupetang" culture=ojibwe }
+1491589 = { name="Samanawhep" culture=ojibwe }
+1491590 = { name="Karpemotoqua" culture=ojibwe }
+1491591 = { name="Lewegshig" culture=ojibwe }
+1491592 = { name="McHoope" culture=ojibwe }
+1491593 = { name="Amateheway" culture=ojibwe }
+1491594 = { name="Telogakyhil" culture=ojibwe }
+1491595 = { name="Sagosegai" culture=ojibwe }
+1491596 = { name="Reardreau" culture=ojibwe }
+1491597 = { name="Gaigwetch" culture=ojibwe }
+1491598 = { name="Ianthwind" culture=ojibwe }
+1491599 = { name="Colsboski" culture=ojibwe }
+1491100 = { name="Barnskezhik" culture=ojibwe }
 
 
 1491601 = { name="Déélgééd" culture=navajo }1491602 = { name="Dodge" culture=navajo }1491603 = { name="Adiits'a'ii" culture=navajo }1491604 = { name="Wauneka" culture=navajo }1491605 = { name="Chischilly" culture=navajo }1491606 = { name="Ahkeah" culture=navajo }1491607 = { name="Atcitty" culture=navajo }1491608 = { name="Zah" culture=navajo }1491609 = { name="Begaye" culture=navajo }1491610 = { name="Dayish" culture=navajo }1491611 = { name="Apachito" culture=navajo }1491612 = { name="Tsinigine" culture=navajo }1491613 = { name="Tsosie" culture=navajo }1491614 = { name="Naize" culture=navajo }1491615 = { name="Yazzie" culture=navajo }1491616 = { name="Nez" culture=navajo }1491617 = { name="Tso" culture=navajo }1491618 = { name="Tapahonso" culture=navajo }1491619 = { name="Nezbah" culture=navajo }1491620 = { name="Sani" culture=navajo }1491621 = { name="Kieyoomia" culture=navajo }1491622 = { name="Bitsui" culture=navajo }1491623 = { name="Yazzie" culture=navajo }1491624 = { name="Tinde" culture=navajo }1491625 = { name="Nakai" culture=navajo }
@@ -589,6 +891,106 @@
 1491808 = { name="Shemaukau" culture=cree }
 1491809 = { name="Kiaskusis" culture=cree }
 1491810 = { name="Pîwâpisk" culture=cree used_for_random=no }
+1491811 = { name="Callingbull" culture=cree }
+1491812 = { name="Cachagee" culture=cree }
+1491813 = { name="Deerchild" culture=cree }
+1491814 = { name="Yellowbird" culture=cree }
+1491815 = { name="Atcheynum" culture=cree }
+1491816 = { name="Greyeyes" culture=cree }
+1491817 = { name="Opekokew" culture=cree }
+1491818 = { name="Settee" culture=cree }
+1491819 = { name="Ominayak" culture=cree }
+1491820 = { name="Goodwill" culture=cree }
+1491821 = { name="Highway" culture=cree }
+1491822 = { name="Cardinal" culture=cree }
+1491823 = { name="Saganash" culture=cree }
+1491824 = { name="Sakahikan" culture=cree }
+1491825 = { name="Tataskweyak" culture=cree }
+1491826 = { name="Mistawasis" culture=cree }
+1491827 = { name="Cikahikan" culture=cree }
+1491828 = { name="Taykwa Tagamou" culture=cree }
+1491829 = { name="Burnstick" culture=cree }
+1491830 = { name="Nisichawayasihk" culture=cree }
+1491831 = { name="Ironquil" culture=cree }
+1491832 = { name="Stonechild" culture=cree }
+1491833 = { name="Wei Mah" culture=cree }
+1491834 = { name="Maskegoniskwew" culture=cree }
+1491835 = { name="Edgelow" culture=cree }
+1491836 = { name="Metatawabin" culture=cree }
+1491837 = { name="Tootoosis" culture=cree }
+1491838 = { name="Saysewahum" culture=cree }
+1491839 = { name="Seesequasis" culture=cree }
+1491840 = { name="Lightning" culture=cree }
+1491841 = { name="Mohkoman" culture=cree }
+1491842 = { name="Ositiyihk" culture=cree }
+1491843 = { name="Waterhen" culture=cree }
+1491844 = { name="Pimicikamak" culture=cree }
+1491845 = { name="Saukamappee" culture=cree }
+1491846 = { name="Frencheater" culture=cree }
+1491847 = { name="Sewepagaham" culture=cree }
+1491848 = { name="Makokis" culture=cree }
+1491849 = { name="Whiskeyjack" culture=cree }
+1491850 = { name="Driftpile" culture=cree }
+1491851 = { name="Shuttleworth" culture=cree }
+1491852 = { name="Aodochouk" culture=cree }
+1491853 = { name="Hatomani" culture=cree }
+1491854 = { name="Ghostkeeper" culture=cree }
+1491855 = { name="Thorphead" culture=cree }
+1491856 = { name="Seemeganis" culture=cree }
+1491857 = { name="Pakadokisini" culture=cree }
+1491858 = { name="Curniyuska" culture=cree }
+1491859 = { name="Ah Kayatow" culture=cree }
+1491860 = { name="Ewaysikum" culture=cree }
+1491861 = { name="Tapekapayewin" culture=cree }
+1491862 = { name="Sakowayeguazo" culture=cree }
+1491863 = { name="Mesekwamiskwan" culture=cree }
+1491864 = { name="Mywayan" culture=cree }
+1491865 = { name="Betshedelkhedi" culture=cree }
+1491866 = { name="Orowepesew" culture=cree }
+1491867 = { name="Eckwaytonkan" culture=cree }
+1491868 = { name="Tokohoopi" culture=cree }
+1491869 = { name="Kartwoman" culture=cree }
+1491870 = { name="Ishnakootah" culture=cree }
+1491871 = { name="Cutfeet" culture=cree }
+1491872 = { name="Kassickoossis" culture=cree }
+1491873 = { name="Singrove" culture=cree }
+1491874 = { name="Swiftbear" culture=cree }
+1491875 = { name="Huntinghawk" culture=cree }
+1491876 = { name="Blackfare" culture=cree }
+1491877 = { name="Syahyasoo" culture=cree }
+1491878 = { name="Lynxleg" culture=cree }
+1491879 = { name="Omenakayo" culture=cree }
+1491880 = { name="Yahyahkeekoot" culture=cree }
+1491881 = { name="Cyahchassay" culture=cree }
+1491882 = { name="Moyah Moyak" culture=cree }
+1491883 = { name="Walkingsun" culture=cree }
+1491884 = { name="Manywounds" culture=cree }
+1491885 = { name="Dodginghorse" culture=cree }
+1491886 = { name="Capateisguays" culture=cree }
+1491887 = { name="Mutaheeguss" culture=cree }
+1491888 = { name="Do Chaykumasceaseepeporo" culture=cree }
+1491889 = { name="Kadaniische" culture=cree }
+1491880 = { name="Mahkay Seace" culture=cree }
+1491881 = { name="Hookimahininis" culture=cree }
+1491882 = { name="Kushoppitit" culture=cree }
+1491883 = { name="Ahinchecapa" culture=cree }
+1491884 = { name="Straightnose" culture=cree }
+1491885 = { name="Okushasis" culture=cree }
+1491886 = { name="Missetwakappo" culture=cree }
+1491887 = { name="Graytwaywaywa" culture=cree }
+1491888 = { name="Pakadokisini" culture=cree }
+1491889 = { name="Wahakahakedon" culture=cree }
+1491890 = { name="Cetahotowi" culture=cree }
+1491891 = { name="Havighankawicohica" culture=cree }
+1491892 = { name="Tasinahdegawi" culture=cree }
+1491893 = { name="Pezihutawakawi" culture=cree }
+1491894 = { name="Makaniahkaska" culture=cree }
+1491895 = { name="Nahohasmani" culture=cree }
+1491896 = { name="Okayihikeyawis" culture=cree }
+1491897 = { name="Hiyetumanis" culture=cree }
+1491898 = { name="Otatakekney" culture=cree }
+1491899 = { name="Soascoopeehoo" culture=cree }
+1491100 = { name="Chimatanim" culture=cree }
 
 1491901 = { name="Tagötöka" culture=paiute
 	coat_of_arms = {
@@ -759,70 +1161,91 @@
 		}
 	} }
 
-1520000 = { name="Mishta-masseku" culture=mikmaq }
-1520001 = { name="Kakupiu-shipu" culture=mikmaq }
-1520002 = { name="Matshiteuiau" culture=mikmaq }
-1520003 = { name="Pessamit" culture=mikmaq }
-1520004 = { name="Uashat" culture=mikmaq }
-1520005 = { name="Ussinitshishu" culture=mikmaq }
-1520006 = { name="Pienshak-shipiss" culture=mikmaq }
-1520007 = { name="Mashteuiatsh" culture=mikmaq }
-1520008 = { name="Uapushkakamau" culture=mikmaq }
-1520009 = { name="Ciseaskikw" culture=mikmaq }
-1520010 = { name="Ushtikuaniss" culture=mikmaq }
-1520011 = { name="Mani-utenam" culture=mikmaq }
-1520012 = { name="Assin" culture=mikmaq }
-1520013 = { name="Shapeiass" culture=mikmaq }
-1520014 = { name="Pakut-shipu" culture=mikmaq }
-1520015 = { name="Unaman-shipu" culture=mikmaq }
-1520016 = { name="Uinnuapishku" culture=mikmaq }
-1520017 = { name="Cisewapaskw" culture=mikmaq }
-1520018 = { name="Mahtn" culture=mikmaq }
-1520019 = { name="Neku" culture=mikmaq }
-1520020 = { name="Isimit" culture=mikmaq }
-1520021 = { name="Iatuekupau-shipu" culture=mikmaq }
-1520022 = { name="Kuekuatsheu-ushui" culture=mikmaq }
-1520023 = { name="Mingan" culture=mikmaq }
-1520024 = { name="Sheshatshiu" culture=mikmaq }
-1520025 = { name="Kamitshuapishekat" culture=mikmaq }
-1520026 = { name="Maliotenam" culture=mikmaq }
-1520027 = { name="Ashuapun-shipu" culture=mikmaq }
-1520028 = { name="Shanti-shipiss" culture=mikmaq }
-1520029 = { name="Kanutinishekasht" culture=mikmaq }
-1520030 = { name="Hipu" culture=mikmaq }
-1520031 = { name="Kaku-paushtiku" culture=mikmaq }
-1520032 = { name="Kanepakasht" culture=mikmaq }
-1520033 = { name="Beechil" culture=mikmaq }
-1520034 = { name="Ushiku-nipi" culture=mikmaq }
-1520035 = { name="Mistanimu" culture=mikmaq }
-1520036 = { name="Matameku-nipi" culture=mikmaq }
-1520037 = { name="Wapaw" culture=mikmaq }
-1520038 = { name="Matamekush" culture=mikmaq }
+1520000 = { name="Gietol" culture=mikmaq }
+1520001 = { name="Abegweit" culture=mikmaq }
+1520002 = { name="Morell" culture=mikmaq }
+1520003 = { name="Buctouche" culture=mikmaq }
+1520004 = { name="Sylliboy" culture=mikmaq }
+1520005 = { name="Ponhook" culture=mikmaq }
+1520006 = { name="Membertou" culture=mikmaq }
+1520007 = { name="Esgenoopetitj" culture=mikmaq }
+1520008 = { name="Mimtugaak" culture=mikmaq }
+1520009 = { name="Kadotpichk" culture=mikmaq }
+1520010 = { name="Gloade" culture=mikmaq }
+1520011 = { name="Potlotek" culture=mikmaq }
+1520012 = { name="Ginnish" culture=mikmaq }
+1520013 = { name="Ugpiganjig" culture=mikmaq }
+1520014 = { name="Hanifan" culture=mikmaq }
+1520015 = { name="Knockwood" culture=mikmaq }
+1520016 = { name="Eskasoni" culture=mikmaq }
+1520017 = { name="Sock" culture=mikmaq }
+1520018 = { name="Cremo" culture=mikmaq }
+1520019 = { name="Basquet" culture=mikmaq }
+1520020 = { name="Upsalquitch" culture=mikmaq }
+1520021 = { name="Listukuj" culture=mikmaq }
+1520022 = { name="Paqtnkek" culture=mikmaq }
+1520023 = { name="Bouzanne" culture=mikmaq }
+1520024 = { name="Hurley" culture=mikmaq }
+1520025 = { name="Benwah" culture=mikmaq }
+1520026 = { name="Skeard" culture=mikmaq }
+1520027 = { name="Metepenagiag" culture=mikmaq }
+1520028 = { name="Tooma" culture=mikmaq }
+1520029 = { name="Jeddore" culture=mikmaq }
+1520030 = { name="Bâtard" culture=mikmaq }
+1520031 = { name="Sanipass" culture=mikmaq }
+1520032 = { name="Aquash" culture=mikmaq }
+1520033 = { name="Jararuse" culture=mikmaq }
+1520034 = { name="Pandanuques" culture=mikmaq }
+1520035 = { name="Sadoques" culture=mikmaq }
+1520036 = { name="Amlamgug" culture=mikmaq }
+1520037 = { name="Dutcher" culture=mikmaq }
+1520038 = { name="Sabattis" culture=mikmaq }
 1520039 = { name="Nikamu" culture=mikmaq }
-1520040 = { name="Nain-shipu" culture=mikmaq }
-1520041 = { name="Nitshiku-nipi" culture=mikmaq }
-1520042 = { name="Kashakasheniut" culture=mikmaq }
-1520043 = { name="Wucu" culture=mikmaq }
-1520044 = { name="Tepiteu-shipu" culture=mikmaq }
-1520045 = { name="Kaminapashkamikau" culture=mikmaq }
-1520046 = { name="Manitupeku" culture=mikmaq }
-1520047 = { name="Essipu" culture=mikmaq }
-1520048 = { name="Kaminishtikutinat" culture=mikmaq }
-1520049 = { name="Nutashkuan" culture=mikmaq }
-1520050 = { name="Kanutameshanut" culture=mikmaq }
-1520051 = { name="Kawawachikamach" culture=mikmaq }
-1520052 = { name="Uciskw" culture=mikmaq }
-1520053 = { name="Mistamahtn" culture=mikmaq }
-1520054 = { name="Yakaw" culture=mikmaq }
-1520055 = { name="Pessamu" culture=mikmaq }
-1520056 = { name="Mani" culture=mikmaq }
-1520057 = { name="Natuashish" culture=mikmaq }
-1520058 = { name="Ifmit" culture=mikmaq }
-1520059 = { name="Kaushetauakamat" culture=mikmaq }
-1520060 = { name="Atim" culture=mikmaq }
-1520061 = { name="Essipit" culture=mikmaq }
-1520062 = { name="Upinau-utshu" culture=mikmaq }
-1520063 = { name="Ekuanitshu" culture=mikmaq }
+1520040 = { name="Athanase" culture=mikmaq }
+1520041 = { name="Obomsawin" culture=mikmaq }
+1520042 = { name="Tufts" culture=mikmaq }
+1520043 = { name="Ranville" culture=mikmaq }
+1520044 = { name="Soegao" culture=mikmaq }
+1520045 = { name="Slweath" culture=mikmaq }
+1520046 = { name="Gesgapegiag" culture=mikmaq }
+1520047 = { name="Poultchous" culture=mikmaq }
+1520048 = { name="Miawpukek" culture=mikmaq }
+1520049 = { name="Wyoush" culture=mikmaq }
+1520050 = { name="Bouabouscache" culture=mikmaq }
+1520051 = { name="Nicholon" culture=mikmaq }
+1520052 = { name="Maffvet" culture=mikmaq }
+1520053 = { name="Geraghty" culture=mikmaq }
+1520054 = { name="Folly" culture=mikmaq }
+1520055 = { name="Lahave" culture=mikmaq }
+1520056 = { name="Etheridge" culture=mikmaq }
+1520057 = { name="Smaknisk" culture=mikmaq }
+1520058 = { name="Qalipu" culture=mikmaq }
+1520059 = { name="Watanumon" culture=mikmaq }
+1520060 = { name="Dedam" culture=mikmaq }
+1520061 = { name="Lacanke" culture=mikmaq }
+1520062 = { name="Nocote" culture=mikmaq }
+1520063 = { name="Lamquin" culture=mikmaq }
+1520064 = { name="Wianabe" culture=mikmaq }
+1520065 = { name="Harquou" culture=mikmaq }
+1520066 = { name="Narvie" culture=mikmaq }
+1520067 = { name="Bartiboque" culture=mikmaq }
+1520068 = { name="Tourex" culture=mikmaq }
+1520069 = { name="Cournaphil" culture=mikmaq }
+1520070 = { name="Tailar" culture=mikmaq }
+1520071 = { name="Mattalique" culture=mikmaq }
+1520072 = { name="Mechlond" culture=mikmaq }
+1520073 = { name="Thonace" culture=mikmaq }
+1520074 = { name="Bariault" culture=mikmaq }
+1520075 = { name="Sark" culture=mikmaq }
+1520076 = { name="Caplain" culture=mikmaq }
+1520077 = { name="Madglon" culture=mikmaq }
+1520078 = { name="Manderson" culture=mikmaq }
+1520079 = { name="Borlow" culture=mikmaq }
+1520080 = { name="Joudry" culture=mikmaq }
+1520081 = { name="Groslouis" culture=mikmaq }
+1520082 = { name="Insadoquis" culture=mikmaq }
+1520083 = { name="Oxouette" culture=mikmaq }
+1520084 = { name="Tahamont" culture=mikmaq }
 
 1521000 = { name="Bathan" culture=tagalog }
 1521001 = { name="Villanueva" culture=tagalog }
@@ -1584,6 +2007,7 @@
 1560054 = { name="Ibañez" culture=agraciado }
 1560055 = { name="Flores" culture=agraciado }
 
+
 1576000 = { name="Kangirsuk" culture=inuit }
 1576001 = { name="Puvirnituq" culture=inuit }
 1576002 = { name="Kuujjuaq" culture=inuit }
@@ -1628,7 +2052,43 @@
 1576041 = { name="Siarut" culture=inuit }
 1576042 = { name="Anaaya" culture=inuit }
 1576043 = { name="Kiggaluk" culture=inuit }
-1576044 = { name="Amaruq" culture=inuit }
+1576044 = { name="Amaruq" culture=inuit }
+1576045 = { name="Kogvik" culture=inuit }
+1576046 = { name="Aglukkaq" culture=inuit }
+1576047 = { name="Irniq" culture=inuit }
+1576048 = { name="Maksagak" culture=inuit }
+1576049 = { name="Kusugak" culture=inuit }
+1576050 = { name="Okalik" culture=inuit }
+1576051 = { name="Savikataaq" culture=inuit }
+1576052 = { name="Aariak" culture=inuit }
+1576053 = { name="Quassa" culture=inuit }
+1576054 = { name="Aglukark" culture=inuit }
+1576055 = { name="Tagaq" culture=inuit }
+1576056 = { name="Tologanak" culture=inuit }
+1576057 = { name="Oonark" culture=inuit }
+1576058 = { name="Iqaqrialu" culture=inuit }
+1576059 = { name="Tapardjuk" culture=inuit }
+1576060 = { name="Enuaraq" culture=inuit }
+1576061 = { name="Ningark" culture=inuit }
+1576062 = { name="Suluk" culture=inuit }
+1576063 = { name="Ungalaaq" culture=inuit }
+1576064 = { name="Kritaqliluk" culture=inuit }
+1576065 = { name="Enuaraq" culture=inuit }
+1576066 = { name="Mapsalak" culture=inuit }
+1576067 = { name="Kattuk" culture=inuit }
+1576068 = { name="Ittinuar" culture=inuit }
+1576069 = { name="Ashoona" culture=inuit }
+1576070 = { name="Tiktaalaaq" culture=inuit }
+1576071 = { name="Gorski" culture=inuit used_for_random=no }
+1576072 = { name="Ulrikab" culture=inuit }
+1576073 = { name="Igloliorte" culture=inuit }
+1576074 = { name="Mukko" culture=inuit }
+1576075 = { name="Shiwak" culture=inuit }
+1576076 = { name="Etok" culture=inuit }
+1576077 = { name="Amagoalik" culture=inuit }
+1576078 = { name="Qumaluk" culture=inuit }
+1576079 = { name="Tullaugaq" culture=inuit }
+1576080 = { name="Qinnuayuaq" culture=inuit }
 
 1583000 = { name="Arroyo" culture=paisa }
 1583001 = { name="Galán" culture=paisa }
@@ -1763,8 +2223,8 @@
 1604046 = { name="Carrel" culture=cayennais }
 1604047 = { name="Chuí" culture=cayennais }
 
-1609000 = { name="Kitpoo" culture=innu }
-1609001 = { name="Kwebek" culture=innu 
+1609000 = { name="Tshakapesh" culture=innu }
+1609001 = { name="Ouiatchouan" culture=innu 
 	coat_of_arms = {
 		religion = norse_pagan
 		template = 0
@@ -1777,85 +2237,75 @@
 			color = 0
 		}
 	}}
-1609002 = { name="Ulustuk" culture=innu }
-1609003 = { name="Kakagwek" culture=innu }
-1609004 = { name="Pesikitk" culture=innu }
-1609005 = { name="Oonban" culture=innu }
-1609006 = { name="Eppayguit" culture=innu }
-1609007 = { name="Miawpukwek" culture=innu }
-1609008 = { name="Shediac" culture=innu }
-1609009 = { name="Wékoqmáq" culture=innu }
-1609010 = { name="Glooscap" culture=innu }
-1609011 = { name="Lustegooch" culture=innu }
-1609012 = { name="Lsetkuk" culture=innu }
-1609013 = { name="Nalkitgoniash" culture=innu }
-1609014 = { name="Agoomakun" culture=innu }
-1609015 = { name="Wékopekwitk" culture=innu }
-1609016 = { name="Ulnooe" culture=innu }
-1609017 = { name="Paqtnkek" culture=innu }
-1609018 = { name="Miramichi" culture=innu }
-1609019 = { name="Lnui Mnikuk" culture=innu }
-1609020 = { name="Kekwajoo" culture=innu }
-1609021 = { name="Pege" culture=innu }
-1609022 = { name="Potlotek" culture=innu }
-1609023 = { name="Mespaak" culture=innu }
-1609024 = { name="Keskapekiaq" culture=innu }
-1609025 = { name="Epekwitk" culture=innu }
-1609026 = { name="Natuaqanek" culture=innu }
-1609027 = { name="Wokumutkook" culture=innu }
-1609028 = { name="Caskumpec" culture=innu }
-1609029 = { name="Akkada" culture=innu }
-1609030 = { name="Eskinuopitijk" culture=innu }
-1609031 = { name="Mes-Adek" culture=innu }
-1609032 = { name="Richibucto" culture=innu }
-1609033 = { name="Waqmitkuk" culture=innu }
-1609034 = { name="Malikiaq" culture=innu }
-1609035 = { name="Keskoospaak" culture=innu }
-1609036 = { name="Chignecto" culture=innu }
-1609037 = { name="Puksaqtéknékatik" culture=innu }
-1609038 = { name="Baktaba" culture=innu }
-1609039 = { name="Amlamkuk Kwesawék" culture=innu }
-1609040 = { name="Kwemoodeech" culture=innu }
-1609041 = { name="Puktusk" culture=innu }
-1609042 = { name="Bostoon" culture=innu }
-1609043 = { name="Lnui Menikuk" culture=innu }
-1609044 = { name="Qalipu" culture=innu }
-1609045 = { name="Kespoogwit" culture=innu }
-1609046 = { name="Maupeltuk" culture=innu }
-1609047 = { name="Kobetek" culture=innu }
-1609048 = { name="Koo'koogwes" culture=innu }
-1609049 = { name="Kobet" culture=innu }
-1609050 = { name="Mooinei" culture=innu }
-1609051 = { name="Kékwapskuk" culture=innu }
-1609052 = { name="Pohomoosh" culture=innu }
-1609053 = { name="Kespék" culture=innu }
-1609054 = { name="Napan" culture=innu }
-1609055 = { name="Ugpi'gangij" culture=innu }
-1609056 = { name="Bookt" culture=innu }
-1609057 = { name="Tabogimkik" culture=innu }
-1609058 = { name="Wékistoqnik" culture=innu }
-1609059 = { name="Pookudapskwode" culture=innu }
-1609060 = { name="Lsipuktuk" culture=innu }
-1609061 = { name="Eskusone" culture=innu }
-1609062 = { name="Pictou" culture=innu }
-1609063 = { name="Pugooopskook" culture=innu }
-1609064 = { name="Segubunakade" culture=innu }
-1609065 = { name="Nabudagwen'igun" culture=innu }
-1609066 = { name="Sipekníkatik" culture=innu }
-1609067 = { name="Kampalijek" culture=innu }
-1609068 = { name="Restigouche" culture=innu }
-1609069 = { name="Munagesunook" culture=innu }
-1609070 = { name="Mabout" culture=innu }
-1609071 = { name="Shubenacadie" culture=innu }
-1609072 = { name="Ntubloo" culture=innu }
-1609073 = { name="Aspatogon" culture=innu }
-1609074 = { name="Metepnákiaq" culture=innu }
-1609075 = { name="Booktoulaygun" culture=innu }
-1609076 = { name="Nipigiguit" culture=innu }
-1609077 = { name="Listikujk" culture=innu }
-1609078 = { name="Kigicapigiak" culture=innu }
-1609079 = { name="Mimkwonmoose" culture=innu }
-1609080 = { name="Ktadoosok" culture=innu }
+1609002 = { name="Kashtin" culture=innu }
+1609003 = { name="Genest" culture=innu }
+1609004 = { name="Meticocho" culture=innu }
+1609005 = { name="Espamichkon" culture=innu }
+1609006 = { name="Swappie" culture=innu }
+1609007 = { name="Vollant" culture=innu }
+1609008 = { name="Sioui" culture=innu }
+1609009 = { name="Mauthaepi" culture=innu }
+1609010 = { name="Kapesh" culture=innu }
+1609011 = { name="Kakouchaki" culture=innu }
+1609012 = { name="Antane" culture=innu }
+1609013 = { name="Jourdain" culture=innu }
+1609014 = { name="Cleary" culture=innu }
+1609015 = { name="Penashue" culture=innu }
+1609016 = { name="Esseigiou" culture=innu }
+1609017 = { name="Ringuette" culture=innu }
+1609018 = { name="Gosfoson" culture=innu }
+1609019 = { name="Piétacho" culture=innu }
+1609020 = { name="Kanapé" culture=innu }
+1609021 = { name="Kurtness" culture=innu }
+1609022 = { name="Nui" culture=innu }
+1609023 = { name="Dix" culture=innu }
+1609024 = { name="Chimo" culture=innu }
+1609025 = { name="John" culture=innu }
+1609026 = { name="Fontaine" culture=innu }
+1609027 = { name="Oukesestigouek" culture=innu }
+1609028 = { name="Mamuitun" culture=innu }
+1609029 = { name="Ulaman" culture=innu }
+1609030 = { name="Mestenapeo" culture=innu }
+1609031 = { name="Teueikan" culture=innu }
+1609032 = { name="Bellefleur" culture=innu }
+1609033 = { name="Iluikoyak" culture=innu }
+1609034 = { name="Menihek" culture=innu }
+1609035 = { name="Utshimassits" culture=innu }
+1609036 = { name="Neskaupe" culture=innu }
+1609037 = { name="Meshkenu" culture=innu }
+1609038 = { name="Takuaikan" culture=innu }
+1609039 = { name="Tshiuetin" culture=innu }
+1609040 = { name="Nussim" culture=innu }
+1609041 = { name="Betshiamits" culture=innu }
+1609042 = { name="Pokue" culture=innu }
+1609043 = { name="Moar" culture=innu }
+1609044 = { name="Kassinu" culture=innu }
+1609045 = { name="Edmonds" culture=innu }
+1609046 = { name="Astouregamigoukh" culture=innu }
+1609047 = { name="Sango" culture=innu }
+1609048 = { name="Atamakaniss" culture=innu }
+1609049 = { name="Iatuekupau" culture=innu }
+1609050 = { name="Shipissipan" culture=innu }
+1609051 = { name="Upmakukueu" culture=innu }
+1609052 = { name="Chabach" culture=innu }
+1609053 = { name="Iskueshish" culture=innu }
+1609054 = { name="Tshishirinish" culture=innu }
+1609055 = { name="Shashumego" culture=innu }
+1609056 = { name="Nissiferpa" culture=innu }
+1609057 = { name="Mestogoche" culture=innu }
+1609058 = { name="Shukushish" culture=innu }
+1609059 = { name="Crepaud" culture=innu }
+1609060 = { name="Matatash" culture=innu }
+1609061 = { name="Nontrecape" culture=innu }
+1609062 = { name="Sternish" culture=innu }
+1609063 = { name="Chetishen" culture=innu }
+1609064 = { name="Williamish" culture=innu }
+1609065 = { name="Quatihicut" culture=innu }
+1609066 = { name="Touphich" culture=innu }
+1609067 = { name="Monikapo" culture=innu }
+1609068 = { name="Picoutlagan" culture=innu }
+1609069 = { name="Ouawash" culture=innu }
+1609070 = { name="Rockway" culture=innu }
 
 1612001 = { name="El Cibolero" culture=neomexicano }1612002 = { name="Maynez" culture=neomexicano }1612003 = { name="de la Concha" culture=neomexicano }1612004 = { name="Contreras" culture=neomexicano }1612005 = { name="Mendoza" culture=neomexicano }1612006 = { name="Melgares" culture=neomexicano }1612007 = { name="de Peralta" culture=neomexicano }1612008 = { name="Manrique" culture=neomexicano }1612009 = { name="de la Mora" culture=neomexicano }1612010 = { name="de Villanueva" culture=neomexicano }1612011 = { name="de Olivade" culture=neomexicano }1612012 = { name="Cubero" culture=neomexicano }1612013 = { name="Vélez" culture=neomexicano }1612014 = { name="Alencaster" culture=neomexicano }1612015 = { name="de Lajanza" culture=neomexicano }1612016 = { name="Sarracino" culture=neomexicano }1612017 = { name="Vizcarra" culture=neomexicano }1612018 = { name="Perea" culture=neomexicano }1612019 = { name="Cresciteundo" culture=neomexicano }1612020 = { name="Suaso" culture=neomexicano }
 
@@ -2363,7 +2813,96 @@
 	} }1755007 = { name="Girouard" culture=acadien }1755008 = { name="Girroir" culture=acadien }1755009 = { name="Aymar" culture=acadien }1755010 = { name="Frenette" culture=acadien }1755011 = { name="Cormier" culture=acadien }1755012 = { name="d'Entremont" culture=acadien }1755013 = { name="LeBlanc" culture=acadien }1755014 = { name="Savoie" culture=acadien }1755015 = { name="Boudroit" culture=acadien }1755016 = { name="Roy-Léveillée" culture=acadien }1755017 = { name="de Dombourg" culture=acadien }1755018 = { name="Auseuil" culture=acadien }1755019 = { name="le Malécite" culture=acadien }
 1755020 = { name="de Graff" culture=acadien }
 1755021 = { name="Dieu-le-Veut" culture=acadien }
-1755022 = { name="de Gaul" culture=acadien }
+1755022 = { name="de Gaul" culture=acadien }
+1755023 = { name="de Nerichac" culture=acadien }
+1755024 = { name="La Joye" culture=acadien }
+1755025 = { name="de Saint-Just" culture=acadien }
+1755026 = { name="Harang" culture=acadien }
+1755027 = { name="de Gédaique" culture=acadien }
+1755028 = { name="Tousquet" culture=acadien }
+1755029 = { name="de l'Ours" culture=acadien }
+1755030 = { name="de La Hève" culture=acadien }
+1755031 = { name="Le Borgne" culture=acadien }
+1755032 = { name="de Jumonville" culture=acadien }
+1755033 = { name="Bedèque" culture=acadien }
+1755034 = { name="de Toulouse" culture=acadien }
+1755035 = { name="Gaspareaux" culture=acadien }
+1755036 = { name="de Nashouat" culture=acadien }
+1755037 = { name="Froiquingont" culture=acadien }
+1755038 = { name="Arsenault" culture=acadien }
+1755039 = { name="La Giroflée" culture=acadien }
+1755040 = { name="Jeanson" culture=acadien }
+1755040 = { name="Buote" culture=acadien }
+1755041 = { name="Godin" culture=acadien }
+1755042 = { name="La Sonde" culture=acadien }
+1755043 = { name="Thibodaux" culture=acadien }
+1755044 = { name="Chiasson" culture=acadien }
+1755045 = { name="Doiron" culture=acadien }
+1755046 = { name="Guedry" culture=acadien }
+1755047 = { name="le Basque" culture=acadien }
+1755048 = { name="de Rohan" culture=acadien }
+1755049 = { name="l'Espagnol" culture=acadien }
+1755050 = { name="Tongrelow" culture=acadien }
+1755051 = { name="Vauquelin" culture=acadien }
+1755052 = { name="Le Loutre" culture=acadien }
+1755053 = { name="Bastarache" culture=acadien }
+1755054 = { name="Trahan" culture=acadien }
+1755055 = { name="Proctor" culture=acadien }
+1755056 = { name="Doucet" culture=acadien }
+1755057 = { name="Soulard" culture=acadien }
+1755058 = { name="de La Frédière" culture=acadien }
+1755059 = { name="Le Maigre" culture=acadien }
+1755060 = { name="Hertel" culture=acadien }
+1755061 = { name="Milfort" culture=acadien }
+1755062 = { name="D'Angeac" culture=acadien }
+1755063 = { name="de la Malgue" culture=acadien }
+1755064 = { name="Subercase" culture=acadien }
+1755065 = { name="Thériault" culture=acadien }
+1755066 = { name="Comeau" culture=acadien }
+1755067 = { name="Ringuette" culture=acadien }
+1755068 = { name="Bourg" culture=acadien }
+1755069 = { name="Friches" culture=acadien }
+1755070 = { name="L'Italien" culture=acadien }
+1755071 = { name="Drisdelle" culture=acadien }
+1755072 = { name="de l'Espérance" culture=acadien }
+1755073 = { name="Dumaresque" culture=acadien }
+1755074 = { name="Chaussegros" culture=acadien }
+1755075 = { name="Huard" culture=acadien }
+1755076 = { name="de Grimross" culture=acadien }
+1755077 = { name="Rossignol" culture=acadien }
+1755078 = { name="Duclos" culture=acadien }
+1755079 = { name="Catalogne" culture=acadien }
+1755080 = { name="Harbec" culture=acadien }
+1755081 = { name="Frigault" culture=acadien }
+1755082 = { name="Durelle" culture=acadien }
+1755083 = { name="Breau" culture=acadien }
+1755084 = { name="Roussel" culture=acadien }
+1755085 = { name="Losier" culture=acadien }
+1755086 = { name="Furneaux" culture=acadien }
+1755087 = { name="Michaud" culture=acadien }
+1755088 = { name="Fallu" culture=acadien }
+1755089 = { name="Lagacé" culture=acadien }
+1755090 = { name="Querry-Bossé" culture=acadien }
+1755091 = { name="Vienneau" culture=acadien }
+1755092 = { name="Giboire-Duvergé" culture=acadien }
+1755093 = { name="Longuépée" culture=acadien }
+1755094 = { name="Legresley" culture=acadien }
+1755095 = { name="Jaillet" culture=acadien }
+1755096 = { name="Vicq" culture=acadien }
+1755097 = { name="Serry" culture=acadien }
+1755098 = { name="Mersereau" culture=acadien }
+1755099 = { name="Chopitany" culture=acadien }
+1755100 = { name="Malenfant" culture=acadien }
+1755101 = { name="Razilly" culture=acadien }
+1755102 = { name="Soulevent" culture=acadien }
+1755103 = { name="Creysac" culture=acadien }
+1755104 = { name="Orillon" culture=acadien }
+1755105 = { name="Mazerolle" culture=acadien }
+1755106 = { name="Lirlandois" culture=acadien }
+1755107 = { name="Tourneur" culture=acadien }
+1755108 = { name="Quémeneur" culture=acadien }
+1755109 = { name="Riendeau" culture=acadien }
+1755110 = { name="Pitre" culture=acadien }
 
 1770000 = { name="Truganini" culture=ozlander }
 1770001 = { name="Oola" culture=ozlander }
@@ -3120,7 +3659,55 @@ coat_of_arms = {
 	}
 }1796049 = { name="d'Ushabatshuan" culture=quebecois }1796050 = { name="Mathieu-Gallant-Giguere" culture=quebecois }1796051 = { name="Cousineau" culture=quebecois }1796052 = { name="Cornud" culture=quebecois }1796053 = { name="de Saint-Rose" culture=quebecois }1796054 = { name="Dugas" culture=quebecois }1796055 = { name="de Kitigàn" culture=quebecois }1796056 = { name="Herstel" culture=quebecois }1796057 = { name="de Langloiserie" culture=quebecois }1796058 = { name="Céloron de Blainville" culture=quebecois }1796059 = { name="Picoté de Belestre" culture=quebecois }1796060 = { name="Le Moyne de Bienville" culture=quebecois }1796061 = { name="des Pins" culture=quebecois }1796062 = { name="Boulerice" culture=quebecois }1796063 = { name="Chauveau" culture=quebecois }1796064 = { name="Demers" culture=quebecois }1796065 = { name="Dufour" culture=quebecois }1796066 = { name="Brunet" culture=quebecois }1796067 = { name="Bourque" culture=quebecois }1796068 = { name="Marchand" culture=quebecois }1796069 = { name="Duplessis" culture=quebecois }1796070 = { name="Marois" culture=quebecois }
 1796071 = { name="Delacroix" culture=quebecois }
-1796072 = { name="de Chomedey" culture=quebecois }
+1796072 = { name="de Maisonneuve" culture=quebecois }
+1796073 = { name="McGee" culture=quebecois }
+1796074 = { name="Martinez" culture=quebecois }
+1796075 = { name="Jetté" culture=quebecois }
+1796076 = { name="de Saint-Veran" culture=quebecois }
+1796077 = { name="de Percé" culture=quebecois }
+1796078 = { name="Ruaux" culture=quebecois }
+1796079 = { name="de la Rivière" culture=quebecois }
+1796080 = { name="Morgentaler" culture=quebecois }
+1796081 = { name="de Niverville" culture=quebecois }
+1796082 = { name="de Saint-Nil" culture=quebecois }
+1796083 = { name="d'Urfé" culture=quebecois }
+1796084 = { name="Phaneuf" culture=quebecois }
+1796085 = { name="Enright" culture=quebecois }
+1796086 = { name="Torrance" culture=quebecois }
+1796087 = { name="Proulx" culture=quebecois }
+1796088 = { name="Bujold" culture=quebecois }
+1796089 = { name="Mulcair" culture=quebecois }
+1796090 = { name="Plouffe" culture=quebecois }
+1796091 = { name="Rizzuto" culture=quebecois }
+1796092 = { name="Nézet-Séguin" culture=quebecois }
+1796093 = { name="Globensky" culture=quebecois }
+1796094 = { name="de Watteville" culture=quebecois }
+1796095 = { name="d'Irumberry" culture=quebecois }
+1796096 = { name="Dykhuis" culture=quebecois }
+1796097 = { name="Bérubé" culture=quebecois }
+1796098 = { name="d'Honguedo" culture=quebecois }
+1796099 = { name="Joncas" culture=quebecois }
+1796100 = { name="des Ormeaux" culture=quebecois }
+1796101 = { name="Fauteux" culture=quebecois }
+1796102 = { name="Angers" culture=quebecois }
+1796103 = { name="de la Roche-Mesquoez" culture=quebecois }
+1796104 = { name="Elgrably" culture=quebecois }
+1796105 = { name="Lauzière" culture=quebecois }
+1796106 = { name="Théberge" culture=quebecois }
+1796107 = { name="Latulippe" culture=quebecois }
+1796108 = { name="de McKayville" culture=quebecois }
+1796109 = { name="Chase-Casgrain" culture=quebecois }
+1796110 = { name="Würtele" culture=quebecois }
+1796111 = { name="Duhamel" culture=quebecois }
+1796112 = { name="d'Outaragasipi" culture=quebecois }
+1796113 = { name="Mousseau" culture=quebecois }
+1796114 = { name="Chicoyne" culture=quebecois }
+1796115 = { name="Francoeur" culture=quebecois }
+1796116 = { name="de Daveluyville" culture=quebecois }
+1796117 = { name="Lizotte" culture=quebecois }
+1796118 = { name="Iracà" culture=quebecois }
+1796119 = { name="Lamquin-Éthier" culture=quebecois }
+1796120 = { name="Grisé" culture=quebecois }
 
 1797000 = { name="Barley" culture=grangelander }1797001 = { name="Rodman" culture=grangelander }1797002 = { name="Amberfield" culture=grangelander }1797003 = { name="Maizeflower" culture=grangelander }1797004 = { name="Strongroot" culture=grangelander }1797005 = { name="Barnes" culture=grangelander }1797006 = { name="Capper" culture=grangelander }1797007 = { name="Gumsore" culture=grangelander }1797008 = { name="Alfafman" culture=grangelander }1797009 = { name="Granlo" culture=grangelander }1797010 = { name="Sereall" culture=grangelander }1797011 = { name="Gammton" culture=grangelander }1797012 = { name="Wheatman" culture=grangelander }1797013 = { name="Beese" culture=grangelander }1797014 = { name="Greysnow" culture=grangelander
 	coat_of_arms = {
@@ -3188,7 +3775,8 @@ coat_of_arms = {
 1812073 = { name="Featherstonehaugh" culture=british }
 
 
-1813000 = { name="Oulton" culture=maritimer }1813001 = { name="Beaton" culture=maritimer
+1813000 = { name="Oulton" culture=maritimer }
+1813001 = { name="Beaton" culture=maritimer
 	coat_of_arms = {
 		template = 0
 		layer = {
@@ -3199,7 +3787,107 @@ coat_of_arms = {
 			color = 0
 			color = 0
 		}
-	} }1813002 = { name="Rale" culture=maritimer }1813003 = { name="Guysbrow" culture=maritimer }1813004 = { name="Beothick" culture=maritimer }1813005 = { name="Homem" culture=maritimer }1813006 = { name="Jacartier" culture=maritimer }1813007 = { name="Tantramar" culture=maritimer }1813008 = { name="Conmara" culture=maritimer }1813009 = { name="Duchambon" culture=maritimer }1813010 = { name="Goldthwait" culture=maritimer }1813011 = { name="Preble" culture=maritimer }1813012 = { name="Rous" culture=maritimer }1813013 = { name="Lexkeith" culture=maritimer }1813014 = { name="Macdonald" culture=maritimer }1813015 = { name="Tracadie" culture=maritimer }1813016 = { name="Beaubassin" culture=maritimer }1813017 = { name="Cocagne" culture=maritimer }1813018 = { name="Jolicure" culture=maritimer }1813019 = { name="Luciphy" culture=maritimer }1813020 = { name="Tidnish" culture=maritimer }1813021 = { name="Uniacke" culture=maritimer }1813022 = { name="Tyndal" culture=maritimer }1813023 = { name="Beecham" culture=maritimer }1813024 = { name="Brundage" culture=maritimer }1813025 = { name="MacKay" culture=maritimer }1813026 = { name="Settlefield" culture=maritimer }1813027 = { name="Aggermore" culture=maritimer }1813028 = { name="Abegweit" culture=maritimer }1813029 = { name="Cuthbert" culture=maritimer }1813030 = { name="de Avonlea" culture=maritimer }1813031 = { name="Cavendish" culture=maritimer }1813032 = { name="Carmody" culture=maritimer }1813033 = { name="Blythe" culture=maritimer }1813034 = { name="Lynde" culture=maritimer }1813035 = { name="Ingleside" culture=maritimer }1813036 = { name="O'Day" culture=maritimer }1813037 = { name="Follows" culture=maritimer }1813038 = { name="Hitt" culture=maritimer }1813039 = { name="Birnberg" culture=maritimer }1813040 = { name="Davison" culture=maritimer }1813041 = { name="O'Connor" culture=maritimer }1813042 = { name="Walsh" culture=maritimer }1813043 = { name="O'Tuairisc" culture=maritimer }1813044 = { name="Mac Scalaidhe" culture= maritimer }1813045 = { name="Bailey" culture=maritimer }1813046 = { name="Bunbury" culture=maritimer }1813047 = { name="Kilmarnock" culture=maritimer }1813048 = { name="Criss" culture=maritimer }1813049 = { name="Crandall" culture=maritimer }
+	} }
+1813002 = { name="Rale" culture=maritimer }
+1813003 = { name="Guysbrow" culture=maritimer }
+1813004 = { name="Beothick" culture=maritimer }
+1813005 = { name="Homem" culture=maritimer }
+1813006 = { name="Jacartier" culture=maritimer }
+1813007 = { name="Tantramar" culture=maritimer }
+1813008 = { name="Conmara" culture=maritimer }
+1813009 = { name="Duchambon" culture=maritimer }
+1813010 = { name="Goldthwait" culture=maritimer }
+1813011 = { name="Preble" culture=maritimer }
+1813012 = { name="Rous" culture=maritimer }
+1813013 = { name="Lexkeith" culture=maritimer }
+1813014 = { name="Macdonald" culture=maritimer }
+1813015 = { name="Tracadie" culture=maritimer }
+1813016 = { name="Beaubassin" culture=maritimer }
+1813017 = { name="Cocagne" culture=maritimer }
+1813018 = { name="Jolicure" culture=maritimer }
+1813019 = { name="Luciphy" culture=maritimer }
+1813020 = { name="Tidnish" culture=maritimer }
+1813021 = { name="Uniacke" culture=maritimer }
+1813022 = { name="Tyndal" culture=maritimer }
+1813023 = { name="Beecham" culture=maritimer }
+1813024 = { name="Brundage" culture=maritimer }
+1813025 = { name="MacKay" culture=maritimer }
+1813026 = { name="Settlefield" culture=maritimer }
+1813027 = { name="Aggermore" culture=maritimer }
+1813028 = { name="Donahew" culture=maritimer }
+1813029 = { name="Cuthbert" culture=maritimer }
+1813030 = { name="de Avonlea" culture=maritimer }
+1813031 = { name="Cavendish" culture=maritimer }
+1813032 = { name="Carmody" culture=maritimer }
+1813033 = { name="Blythe" culture=maritimer }
+1813034 = { name="Lynde" culture=maritimer }
+1813035 = { name="Ingleside" culture=maritimer }
+1813036 = { name="O'Day" culture=maritimer }
+1813037 = { name="Follows" culture=maritimer }
+1813038 = { name="Hitt" culture=maritimer }
+1813039 = { name="Birnberg" culture=maritimer }
+1813040 = { name="Davison" culture=maritimer }
+1813041 = { name="O'Connor" culture=maritimer }
+1813042 = { name="Walsh" culture=maritimer }
+1813043 = { name="O'Tuairisc" culture=maritimer }
+1813044 = { name="Mac Scalaidhe" culture= maritimer }
+1813045 = { name="Bailey" culture=maritimer }
+1813046 = { name="Bunbury" culture=maritimer }
+1813047 = { name="Kilmarnock" culture=maritimer 
+1813048 = { name="Criss" culture=maritimer }
+1813049 = { name="Crandall" culture=maritimer }
+1813050 = { name="Phips" culture=maritimer }
+1813051 = { name="Cunard" culture=maritimer }
+1813052 = { name="Peggy" culture=maritimer }
+1813053 = { name="Bannerman" culture=maritimer }
+1813054 = { name="Hutchinson" culture=maritimer }
+1813055 = { name="Sebastopol" culture=maritimer }
+1813056 = { name="Buchanan" culture=maritimer }
+1813057 = { name="Annand" culture=maritimer }
+1813058 = { name="Vetch" culture=maritimer }
+1813059 = { name="Arbuthnot" culture=maritimer }
+1813060 = { name="Ghiz" culture=maritimer }
+1813061 = { name="Jeffery" culture=maritimer }
+1813062 = { name="Maudgomery" culture=maritimer }
+1813063 = { name="McLelan" culture=maritimer }
+1813064 = { name="MacKeen" culture=maritimer }
+1813065 = { name="Bazalgette" culture=maritimer }
+1813066 = { name="Daisley" culture=maritimer }
+1813067 = { name="Maitland" culture=maritimer }
+1813068 = { name="Tarantine" culture=maritimer }
+1813069 = { name="Toller" culture=maritimer }
+1813070 = { name="Hebron" culture=maritimer }
+1813071 = { name="Wasson" culture=maritimer }
+1813072 = { name="Gesner" culture=maritimer }
+1813073 = { name="Hall" culture=maritimer }
+1813074 = { name="Macarmick" culture=maritimer }
+1813075 = { name="Hennessey" culture=maritimer }
+1813076 = { name="Irving" culture=maritimer 
+1813077 = { name="Irving" culture=maritimer 
+1813078 = { name="Caissie" culture=maritimer }
+1813079 = { name="Saltzman" culture=maritimer }
+1813080 = { name="Merrithew" culture=maritimer }
+1813081 = { name="Gorman" culture=maritimer }
+1813082 = { name="McMonagle" culture=maritimer }
+1813083 = { name="Olscamp" culture=maritimer }
+1813084 = { name="Bronnum" culture=maritimer }
+1813085 = { name="Payzant" culture=maritimer }
+1813086 = { name="Fairbairn" culture=maritimer }
+1813087 = { name="Compton" culture=maritimer }
+1813088 = { name="Saumarez" culture=maritimer }
+1813089 = { name="McCready" culture=maritimer }
+1813090 = { name="Trenholme" culture=maritimer }
+1813091 = { name="Stracey" culture=maritimer }
+1813092 = { name="O'Ree" culture=maritimer }
+1813093 = { name="Moncrieff" culture=maritimer }
+1813094 = { name="Dingwall" culture=maritimer }
+1813095 = { name="Gallivan" culture=maritimer }
+1813096 = { name="Handrahan" culture=maritimer }
+1813097 = { name="MacEachern" culture=maritimer }
+1813098 = { name="Ganong" culture=maritimer }
+1813099 = { name="Ochiltree" culture=maritimer }
+1813100 = { name="Hierlihy" culture=maritimer }
+
 
 1814000 = { name="Pfardentrott" culture=texan }1814001 = { name="Rusk" culture=texan }1814002 = { name="Zanco" culture=texan }1814003 = { name="Hannegan" culture=texan
 	coat_of_arms = {
@@ -4091,17 +4779,17 @@ coat_of_arms = {
 
 1867000 = { name="Grune" culture=ontarian }
 1867001 = { name="Movenpick" culture=ontarian }
-1867002 = { name="Hamar" culture=ontarian }
+1867002 = { name="Yonge" culture=ontarian }
 1867003 = { name="Montrose" culture=ontarian }
 1867004 = { name="Ranger" culture=ontarian }
 1867005 = { name="Shaughnessy" culture=ontarian }
 1867006 = { name="Frid" culture=ontarian }
 1867007 = { name="Tremblay" culture=ontarian }
 1867008 = { name="Dunsworth" culture=ontarian }
-1867009 = { name="Harpist" culture=ontarian }
+1867009 = { name="Hees" culture=ontarian }
 1867010 = { name="Beasley" culture=ontarian }
 1867011 = { name="Duff" culture=ontarian }
-1867012 = { name="Baby" culture=ontarian }
+1867012 = { name="Tory" culture=ontarian }
 1867013 = { name="Humber" culture=ontarian }
 1867014 = { name="Watson" culture=ontarian }
 1867015 = { name="Laurier" culture=ontarian
@@ -4119,19 +4807,161 @@ coat_of_arms = {
 1867016 = { name="Aylen" culture=ontarian }
 1867017 = { name="de Bonnechere" culture=ontarian }
 1867018 = { name="de Michelenburg" culture=ontarian }
-1867019 = { name="Williams" culture=ontarian }
-1867020 = { name="Lanark" culture=ontarian }
+1867019 = { name="Cordova" culture=ontarian 
+    coat_of_arms = {
+        template = 0
+        layer = {
+            texture = 9
+            texture_internal = 39
+            emblem = 0
+            color = 5
+            color = 13
+            color = 0
+        }
+     }}
+1867020 = { name="Lanark" culture=ontarian 
+    coat_of_arms = {
+        template = 0
+        layer = {
+            texture = 2
+            texture_internal = 9
+            emblem = 0
+            color = 3
+            color = 3
+            color = 1
+        }
+     }}
 1867021 = { name="Branch" culture=ontarian }
-1867022 = { name="Dysart" culture=ontarian }
+1867022 = { name="Dysart" culture=ontarian 
+    coat_of_arms = {
+        template = 0
+        layer = {
+            texture = 10
+            texture_internal = 25
+            emblem = 0
+            color = 1
+            color = 11
+            color = 8
+        }
+     }}
 1867023 = { name="Onaping" culture=ontarian }
 1867024 = { name="Chicona" culture=ontarian }
-1867025 = { name="Oldhome" culture=ontarian }1867026 = { name="Beckett" culture=ontarian }
+1867025 = { name="Oldhome" culture=ontarian }
+1867026 = { name="Beckett" culture=ontarian }
 1867027 = { name="Hobbs" culture=ontarian }
 1867028 = { name="Hudson" culture=ontarian }
-1867029 = { name="Mackenzie" culture=ontarian }
+1867029 = { name="McKenzie" culture=ontarian }
 1867030 = { name="Stills" culture=ontarian }
 1867031 = { name="Pine" culture=ontarian }
 1867032 = { name="Nordegraf" culture=ontarian }
+1867033 = { name="Oosterhoff" culture=ontarian }
+1867034 = { name="Wynne" culture=ontarian }
+1867035 = { name="Tement" culture=ontarian }
+1867036 = { name="Horvath" culture=ontarian }
+1867037 = { name="Bloor" culture=ontarian }
+1867038 = { name="Amherst" culture=ontarian }
+1867039 = { name="de Freelton" culture=ontarian }
+1867040 = { name="Cressy" culture=ontarian }
+1867041 = { name="Hakim" culture=ontarian }
+1867042 = { name="Yelleck" culture=ontarian }
+1867043 = { name="Hungerford" culture=ontarian }
+1867044 = { name="Coe" culture=ontarian }
+1867045 = { name="Hoodless" culture=ontarian }
+1867046 = { name="de Quinte" culture=ontarian }
+1867047 = { name="de Thames" culture=ontarian }
+1867048 = { name="Tomiko" culture=ontarian }
+1867049 = { name="Achray" culture=ontarian }
+1867050 = { name="Robarts" culture=ontarian }
+1867051 = { name="Creemore" culture=ontarian }
+1867052 = { name="Dundalk" culture=ontarian }
+1867053 = { name="Qadri" culture=ontarian }
+1867054 = { name="Loughbreeze" culture=ontarian }
+1867055 = { name="Dowitcher" culture=ontarian }
+1867056 = { name="Losz" culture=ontarian }
+1867057 = { name="Harbord" culture=ontarian }
+1867058 = { name="Hahn" culture=ontarian }
+1867059 = { name="Spadina" culture=ontarian }
+1867060 = { name="de Wilno" culture=ontarian }
+1867061 = { name="Gzowski" culture=ontarian }
+1867062 = { name="Norgoma" culture=ontarian }
+1867063 = { name="Burgoyne" culture=ontarian }
+1867064 = { name="Conestoga" culture=ontarian }
+1867065 = { name="Kawawaymog" culture=ontarian }
+1867066 = { name="Musitano" culture=ontarian }
+1867067 = { name="Roncesvalles" culture=ontarian }
+1867068 = { name="Chisolm" culture=ontarian }
+1867069 = { name="Temelkoski" culture=ontarian }
+1867070 = { name="Onley" culture=ontarian }
+1867071 = { name="Van Kleek" culture=ontarian }
+1867072 = { name="Reynales" culture=ontarian }
+1867073 = { name="Lockport" culture=ontarian }
+1867074 = { name="Neyagawa" culture=ontarian }
+1867075 = { name="von Schoultz" culture=ontarian }
+1867076 = { name="Irondequoit" culture=ontarian }
+1867077 = { name="de Mikisew" culture=ontarian }
+1867078 = { name="Severn" culture=ontarian }
+1867079 = { name="Gilhooly" culture=ontarian }
+1867080 = { name="de Bronte" culture=ontarian }
+1867081 = { name="Aldershot" culture=ontarian }
+1867082 = { name="de Glengarry" culture=ontarian }
+1867083 = { name="Stormont" culture=ontarian }
+1867084 = { name="Ionview" culture=ontarian }
+1867085 = { name="Ouwerkerk" culture=ontarian }
+1867086 = { name="Rae" culture=ontarian }
+1867087 = { name="Kensington" culture=ontarian }
+1867088 = { name="de Schomberg" culture=ontarian }
+1867089 = { name="Giambrone" culture=ontarian }
+1867090 = { name="Bailao" culture=ontarian }
+1867091 = { name="Vrooman" culture=ontarian }
+1867092 = { name="Runchey" culture=ontarian }
+1867093 = { name="McKillop" culture=ontarian }
+1867094 = { name="Breithaupt" culture=ontarian }
+1867095 = { name="de Johnstown" culture=ontarian }
+1867096 = { name="Neyagawa" culture=ontarian }
+1867097 = { name="Strange" culture=ontarian }
+1867098 = { name="Snelgrove" culture=ontarian }
+1867099 = { name="Jessup" culture=ontarian }
+1867100 = { name="Gromley" culture=ontarian }
+1867101 = { name="Zaugg" culture=ontarian }  
+1867102 = { name="Obrowatz" culture=ontarian }    
+1867103 = { name="Hammer" culture=ontarian }      
+1867104 = { name="Bains" culture=ontarian }
+1867105 = { name="McMichael" culture=ontarian }
+1867106 = { name="Sharma" culture=ontarian }
+1867107 = { name="Torbram" culture=ontarian }
+1867108 = { name="Dundurn" culture=ontarian }
+1867109 = { name="Cootes" culture=ontarian }
+1867110 = { name="Hudak" culture=ontarian }
+1867111 = { name="Strachan" culture=ontarian }
+1867112 = { name="Fearnsides" culture=ontarian }
+1867113 = { name="Ambrister" culture=ontarian }
+1867114 = { name="Yeo" culture=ontarian }
+1867115 = { name="Pakenham" culture=ontarian }
+1867116 = { name="Mendez" culture=ontarian }
+1867117 = { name="Christiansen" culture=ontarian }
+1867118 = { name="de Castlederg" culture=ontarian }
+1867119 = { name="Wyecroft" culture=ontarian }
+1867120 = { name="Gardiner" culture=ontarian }
+1867121 = { name="Northland" culture=ontarian }
+1867122 = { name="Yakabuski" culture=ontarian }
+1867123 = { name="DeGroote" culture=ontarian }
+1867124 = { name="Lount" culture=ontarian }
+1867125 = { name="d'Almaguin" culture=ontarian }
+1867126 = { name="Donnelly" culture=ontarian }
+1867127 = { name="DaGuinty" culture=ontarian }
+1867128 = { name="Urquhart" culture=ontarian }
+1867129 = { name="Breakenridge" culture=ontarian }
+1867130 = { name="d'Ossington" culture=ontarian }
+1867131 = { name="Gonez" culture=ontarian }
+1867132 = { name="Flynn" culture=ontarian }
+1867133 = { name="de Wentworth" culture=ontarian }
+1867134 = { name="Badawey" culture=ontarian }
+1867135 = { name="Wissanotti" culture=ontarian }
+1867136 = { name="van Koeverden" culture=ontarian }
+1867137 = { name="Eglinton" culture=ontarian }
+1867138 = { name="FitzGibbon" culture=ontarian }
+1867139 = { name="Dunlop" culture=ontarian }
+1867140 = { name="Porter" culture=ontarian }
 
 
 1869000 = { name="Riel" culture=metis }
@@ -4165,7 +4995,7 @@ coat_of_arms = {
 1869016 = { name="Beauchemin" culture=metis }
 1869017 = { name="Vautour" culture=metis }
 1869018 = { name="Vermette" culture=metis }
-1869019 = { name="Desjarlais" culture=metis }
+1869019 = { name="Letendre" culture=metis }
 1869020 = { name="Montour" culture=metis }
 1869021 = { name="Chartrand" culture=metis }
 1869022 = { name="Chalifoux" culture=metis }
@@ -4173,10 +5003,100 @@ coat_of_arms = {
 1869024 = { name="Hivernant" culture=metis }
 1869025 = { name="Batoche" culture=metis }
 1869026 = { name="Southbranch" culture=metis }
-1869027 = { name="Moccasin" culture=metis }
+1869027 = { name="de Padoue" culture=metis }
 1869028 = { name="Boniface" culture=metis }
-1869029 = { name="Beaver" culture=metis }
-1869030 = { name="Saulteaux" culture=metis }
+1869029 = { name="Guiboche" culture=metis }
+1869030 = { name="Saulteaux" culture=metis }
+1869031 = { name="Cutknife" culture=metis }
+1869032 = { name="Qu'Appelle" culture=metis }
+1869033 = { name="Sayer" culture=metis }
+1869034 = { name="Bellehumeur" culture=metis }
+1869035 = { name="Isbister" culture=metis }
+1869036 = { name="Scofield" culture=metis }
+1869037 = { name="Dauphinais" culture=metis }
+1869038 = { name="Episkenew" culture=metis }
+1869039 = { name="Fafard" culture=metis }
+1869040 = { name="Tourond" culture=metis }
+1869041 = { name="Garrioch" culture=metis }
+1869042 = { name="DeMontigny" culture=metis }
+1869043 = { name="Breland" culture=metis }
+1869044 = { name="Gunn" culture=metis }
+1869045 = { name="Poitras" culture=metis }
+1869046 = { name="Shanks" culture=metis }
+1869047 = { name="Houle" culture=metis }
+1869048 = { name="Bruneau" culture=metis }
+1869049 = { name="Teillet" culture=metis }
+1869050 = { name="McNarland" culture=metis }
+1869051 = { name="Eklund" culture=metis }
+1869052 = { name="Mercredi" culture=metis }
+1869053 = { name="Throssel" culture=metis }
+1869054 = { name="La Ronge" culture=metis }
+1869055 = { name="Tomlinson" culture=metis }
+1869056 = { name="Trottier" culture=metis }
+1869057 = { name="Turpel" culture=metis }
+1869058 = { name="Fleury" culture=metis }
+1869059 = { name="O'Soup" culture=metis }
+1869060 = { name="Chatelain" culture=metis }
+1869061 = { name="Zastre" culture=metis }
+1869062 = { name="Lafond" culture=metis }
+1869063 = { name="Lafleche" culture=metis }
+1869064 = { name="Hubbard" culture=metis }
+1869065 = { name="Massimo" culture=metis }
+1869066 = { name="Calahasen" culture=metis }
+1869067 = { name="de Jarlis" culture=metis }
+1869068 = { name="Ouellette" culture=metis }
+1869069 = { name="de Vegreville" culture=metis }
+1869070 = { name="Gardepy" culture=metis }
+1869071 = { name="Sourdif" culture=metis }
+1869072 = { name="Shebepzek" culture=metis }
+1869073 = { name="Ritchot" culture=metis }
+1869074 = { name="Singosobie" culture=metis }
+1869075 = { name="McKweassige" culture=metis }
+1869076 = { name="L'Hirondelle" culture=metis }
+1869077 = { name="Charpentier" culture=metis }
+1869078 = { name="Abrahamson" culture=metis }
+1869079 = { name="Bissaillon" culture=metis }
+1869080 = { name="O'Kweziesai" culture=metis }
+1869081 = { name="Alg-Hay" culture=metis }
+1869082 = { name="La Pretre" culture=metis }
+1869083 = { name="Hothwell" culture=metis }
+1869084 = { name="Mascasin" culture=metis }
+1869085 = { name="Baikie" culture=metis }
+1869086 = { name="Gemerce" culture=metis }
+1869087 = { name="Guimmond" culture=metis }
+1869088 = { name="Courchene" culture=metis }
+1869089 = { name="Savoyad" culture=metis }
+1869090 = { name="Saint-Arneault" culture=metis }
+1869091 = { name="Duguette" culture=metis }
+1869092 = { name="Longsneck" culture=metis }
+1869093 = { name="Wayshorn" culture=metis }
+1869094 = { name="Mercival" culture=metis }
+1869095 = { name="Chalizonnce" culture=metis }
+1869096 = { name="Rohllard" culture=metis }
+1869097 = { name="Tourangean" culture=metis }
+1869098 = { name="Chenalque" culture=metis }
+1869099 = { name="Loguier" culture=metis }
+1869100 = { name="Halliday" culture=metis }
+1869101 = { name="Norwest" culture=metis }
+1869102 = { name="Dickson" culture=metis }
+1869103 = { name="Forget" culture=metis }
+1869104 = { name="Jackatar" culture=metis }
+1869105 = { name="Préfontaine" culture=metis }
+1869106 = { name="Tremaudan" culture=metis }
+1869107 = { name="Racette" culture=metis }
+1869108 = { name="Overvold" culture=metis }
+1869109 = { name="Ritchot" culture=metis }
+1869110 = { name="Zebeaux" culture=metis }
+1869111 = { name="Zoldy" culture=metis }
+1869112 = { name="Boyer" culture=metis }
+1869113 = { name="Shikawk" culture=metis }
+1869114 = { name="Combot" culture=metis }
+1869115 = { name="LiShyen" culture=metis }
+1869116 = { name="Misponas" culture=metis }
+1869117 = { name="Nolin" culture=metis }
+1869118 = { name="Leost" culture=metis }
+1869119 = { name="Tuharsky" culture=metis }
+1869120 = { name="Hourie" culture=metis }
 
 1876001 = { name="Nilsinenumine" culture=coloradan }1876002 = { name="Croke" culture=coloradan }1876003 = { name="Brass" culture=coloradan }1876004 = { name="Lamm" culture=coloradan }1876005 = { name="Cory-Merrill" culture=coloradan }1876006 = { name="Ricketts" culture=coloradan }1876007 = { name="Balch" culture=coloradan }1876008 = { name="Batterton" culture=coloradan }1876009 = { name="Begole" culture=coloradan }1876010 = { name="Brendinger" culture=coloradan }1876011 = { name="Sopris" culture=coloradan }1876012 = { name="Steck" culture=coloradan }1876013 = { name="Routt" culture=coloradan }1876014 = { name="Currigan" culture=coloradan }1876015 = { name="Speer" culture=coloradan }1876016 = { name="Buchtel" culture=coloradan }1876017 = { name="Pitkin" culture=coloradan }1876018 = { name="Meldrum" culture=coloradan }1876019 = { name="Haggott" culture=coloradan }1876020 = { name="Bronck" culture=coloradan }1876021 = { name="Howsam" culture=coloradan }1876022 = { name="Cheesman" culture=coloradan }1876023 = { name="Ricketts" culture=coloradan }1876024 = { name="Kunsmiller" culture=coloradan }1876025 = { name="Kepner" culture=coloradan }1876026 = { name="Wyateson" culture=coloradan }1876027 = { name="Swigert" culture=coloradan }1876028 = { name="Gessler" culture=coloradan }1876029 = { name="Renfoe" culture=coloradan }1876030 = { name="Stotch" culture=coloradan }1876031 = { name="Packer" culture=coloradan }1876032 = { name="Bent" culture=coloradan }1876033 = { name="Poudre" culture=coloradan }1876034 = { name="Flatiron" culture=coloradan }1876035 = { name="Valmer" culture=coloradan }1876036 = { name="Trapper" culture=coloradan }
 
@@ -4185,7 +5105,7 @@ coat_of_arms = {
 1886002 = { name="Cantrell" culture=canuck }
 1886003 = { name="Newell" culture=canuck }
 1886004 = { name="Deighton" culture=canuck }
-1886005 = { name="Strathcona" culture=canuck }
+1886005 = { name="Kobayashi" culture=canuck }
 1886006 = { name="Granville" culture=canuck }
 1886007 = { name="Messier" culture=canuck
 	coat_of_arms = {
@@ -4223,15 +5143,107 @@ coat_of_arms = {
 1886028 = { name="Coupland" culture=canuck }
 1886029 = { name="Hartwell" culture=canuck }
 1886030 = { name="Vedder" culture=canuck }
-1886031 = { name="Fraser" culture=canuck }
-1886032 = { name="John-Luke" culture=canuck }1886033 = { name="Williams" culture=canuck used_for_random=no }
+1886031 = { name="Pottruff" culture=canuck }
+1886032 = { name="John-Luke" culture=canuck }
+1886033 = { name="Service" culture=canuck }
 1886034 = { name="Courtenay" culture = canuck }
 1845035 = { name="Qubean" culture = canuck }
 1845036 = { name="Plett" culture = canuck }
 1845037 = { name="Anderson" culture = canuck }
-1845038 = { name="Vancouver" culture = canuck }
+1845038 = { name="Bayring" culture = canuck }
 1845039 = { name="Chau" culture = canuck }
 1845040 = { name="Lee" culture = canuck }
+1886040 = { name="Kaminishi" culture=canuck }
+1886041 = { name="Canning" culture=canuck }
+1886042 = { name="Miyazaki" culture=canuck }
+1886043 = { name="Huskisson" culture=canuck }
+1886044 = { name="Grizzly" culture=canuck }
+1886045 = { name="Asahi" culture=canuck }
+1886046 = { name="Sakic" culture=canuck }
+1886047 = { name="Huang" culture=canuck }
+1886048 = { name="De Cosmos" culture=canuck }
+1886049 = { name="Edzerza" culture=canuck }
+1886050 = { name="Penikett" culture=canuck }
+1886051 = { name="San Miguel" culture=canuck }
+1886052 = { name="Clah" culture=canuck }
+1886053 = { name="Campagnolo" culture=canuck }
+1886054 = { name="Dosanjh" culture=canuck }
+1886055 = { name="Tryggvason" culture=canuck }
+1886056 = { name="Yzerman" culture=canuck }
+1886057 = { name="Wolfhard" culture=canuck }
+1886058 = { name="Scow" culture=canuck }
+1886059 = { name="Carrier" culture=canuck }
+1886060 = { name="Kanaka" culture=canuck }
+1886061 = { name="Pattullo" culture=canuck }
+1886062 = { name="Burrard" culture=canuck }
+1886063 = { name="Zalm" culture=canuck }
+1886064 = { name="Quadra" culture=canuck }
+1886065 = { name="de Fuca" culture=canuck }
+1886066 = { name="Steller" culture=canuck }
+1886067 = { name="Lou-Poy" culture=canuck }
+1886068 = { name="Tyrwhitt" culture=canuck }
+1886069 = { name="Sajjan" culture=canuck }
+1886070 = { name="Yiu" culture=canuck }
+1886071 = { name="Esselmont" culture=canuck }
+1886072 = { name="Wing" culture=canuck }
+1886073 = { name="Galgardi" culture=canuck }
+1886074 = { name="Inouye" culture=canuck }
+1886075 = { name="Chara" culture=canuck }
+1886076 = { name="Ussher" culture=canuck }
+1886077 = { name="Moody" culture=canuck }
+1886078 = { name="Koyczan" culture=canuck }
+1886079 = { name="Musclow" culture=canuck }
+1886080 = { name="Krug" culture=canuck }
+1886081 = { name="Homathko" culture=canuck }
+1886082 = { name="Sockeye" culture=canuck }
+1886083 = { name="Texada" culture=canuck }
+1886084 = { name="Oppel" culture=canuck }
+1886085 = { name="Jespersen" culture=canuck }
+1886086 = { name="Sproat" culture=canuck }
+1886087 = { name="D'Herbomez" culture=canuck }
+1886088 = { name="Norrish" culture=canuck }
+1886089 = { name="Bilodeau" culture=canuck }
+1886090 = { name="Tseng" culture=canuck }
+1886091 = { name="Odlum" culture=canuck }
+1886092 = { name="Estrada" culture=canuck }
+1886093 = { name="Granholm" culture=canuck }
+1886094 = { name="Hsiao" culture=canuck }
+1886095 = { name="Taku" culture=canuck }
+1886096 = { name="Cwynar" culture=canuck }
+1886097 = { name="Bonifacho" culture=canuck }
+1886098 = { name="Dhaliwal" culture=canuck }
+1886099 = { name="Petrie" culture=canuck }
+1886100 = { name="Makawicjuk" culture=canuck }
+1886101 = { name="Lanfong" culture=canuck }
+1886102 = { name="Hakamaugh" culture=canuck }
+1886103 = { name="Whannell" culture=canuck }
+1886104 = { name="Songhee" culture=canuck }
+1886105 = { name="Lyackson" culture=canuck }
+1886106 = { name="Slaholt" culture=canuck }
+1886107 = { name="Teit" culture=canuck }
+1886108 = { name="Vetenaro" culture=canuck }
+1886109 = { name="Boas" culture=canuck }
+1886110 = { name="Khay-Tulk" culture=canuck }
+1886111 = { name="San Josef" culture=canuck }
+1886112 = { name="Hupacasath" culture=canuck }
+1886113 = { name="Neroustos" culture=canuck }
+1886114 = { name="Clowhom" culture=canuck }
+1886115 = { name="Lasqueti" culture=canuck }
+1886116 = { name="Cayley" culture=canuck }
+1886117 = { name="Phair" culture=canuck }
+1886118 = { name="Gouk" culture=canuck }
+1886119 = { name="Brind'Amour" culture=canuck }
+1886120 = { name="Ito" culture=canuck }
+1886121 = { name="Gullach" culture=canuck }
+1886122 = { name="Huitema" culture=canuck }
+1886123 = { name="Onderdonk" culture=canuck }
+1886124 = { name="Ueno" culture=canuck }
+1886125 = { name="Meikus" culture=canuck }
+1886126 = { name="Horiuchi" culture=canuck }
+1886127 = { name="Crowle" culture=canuck }
+1886128 = { name="Berarduc" culture=canuck }
+1886129 = { name="Tsawenhohi" culture=canuck }
+1886130 = { name="Anaham" culture=canuck }
 
 
 1889001 = { name="Shobann" culture=mountainer }1889002 = { name="Moynardier" culture=mountainer }1889003 = { name="Desmet" culture=mountainer }1889004 = { name="Gunnison" culture=mountainer }1889005 = { name="Meek" culture=mountainer }1889006 = { name="Drewyer" culture=mountainer }1889007 = { name="Glass" culture=mountainer }1889008 = { name="Fairweather" culture=mountainer
@@ -5232,6 +6244,38 @@ coat_of_arms = {
 2007051 = { name="Teseroken" culture=iroquois }
 2007052 = { name="Tetosweken" culture=iroquois }
 2007053 = { name="Yoroonwago" culture=iroquois }
+2007054 = { name="Longley" culture=iroquois }
+2007055 = { name="Kulikovsky" culture=iroquois used_for_random=no }
+2007056 = { name="Toudaman" culture=iroquois }
+2007057 = { name="Greene" culture=iroquois }
+2007058 = { name="Lawinonkie" culture=iroquois }
+2007059 = { name="Nanticoke" culture=iroquois }
+2007060 = { name="Massaubi" culture=iroquois }
+2007061 = { name="Two-Axe" culture=iroquois }
+2007062 = { name="Loft" culture=iroquois }
+2007063 = { name="Oakes" culture=iroquois }
+2007064 = { name="Verelst" culture=iroquois }
+2007065 = { name="Garacontie" culture=iroquois }
+2007066 = { name="Gansworth" culture=iroquois }
+2007067 = { name="Tehanetorens" culture=iroquois }
+2007068 = { name="Hastination" culture=iroquois }
+2007069 = { name="Wheelock" culture=iroquois }
+2007070 = { name="Cattaraugus" culture=iroquois }
+2007071 = { name="Hononwirehdonh" culture=iroquois }
+2007072 = { name="Cusick" culture=iroquois }
+2007073 = { name="Rickard" culture=iroquois }
+2007074 = { name="Hanyerry" culture=iroquois }
+2007075 = { name="Cornelius" culture=iroquois }
+2007076 = { name="Skenandoa" culture=iroquois }
+2007077 = { name="Teiaiagon" culture=iroquois }
+2007078 = { name="Onaquaga" culture=iroquois }
+2007079 = { name="Chedoke" culture=iroquois }
+2007080 = { name="Tsyonyatih" culture=iroquois }
+2007081 = { name="Quinaouatoua" culture=iroquois }
+2007082 = { name="Abeel" culture=iroquois }
+2007083 = { name="Chenussio" culture=iroquois }
+2007084 = { name="Queanettquaga" culture=iroquois }
+2007085 = { name="Gyonohsadegeh" culture=iroquois }
 
 #All names taken from the Wikipedia article for carpetbagger. (These include Southerners from non-Confederate states and black Americans.)
 2008001 = { name="Ames" culture=carpetbagger }
@@ -5478,6 +6522,43 @@ coat_of_arms = {
 2014060 = { name="Sylvestre" culture=ontarois }
 2014061 = { name="Tostevin" culture=ontarois }
 2014062 = { name="Trebek" culture=ontarois }
+2014063 = { name="Trevisanut" culture=ontarois }
+2014064 = { name="Lafarge" culture=ontarois }
+2014065 = { name="Desjardins" culture=ontarois }
+2014066 = { name="Ayotte" culture=ontarois }
+2014067 = { name="Filion" culture=ontarois }
+2014068 = { name="Ndur" culture=ontarois }
+2014069 = { name="Bourgouin" culture=ontarois }
+2014070 = { name="Simard" culture=ontarois }
+2014071 = { name="DeCou" culture=ontarian }
+2014072 = { name="LeLièvre" culture=ontarian }
+2014073 = { name="Prévost" culture=ontarian }
+2014074 = { name="Plourde" culture=ontarian }
+2014075 = { name="Sigouin" culture=ontarian }
+2014076 = { name="Cléroux" culture=ontarian }
+2014077 = { name="Carscallen" culture=ontarian }
+2014078 = { name="Courtemanche" culture=ontarian }
+2014079 = { name="Esmie" culture=ontarian }
+2014080 = { name="Adetuyi" culture=ontarian }
+2014081 = { name="Scollard" culture=ontarian }
+2014082 = { name="Damphousse" culture=ontarian }
+2014083 = { name="Bailloquet" culture=ontarian }
+2014084 = { name="Marcoux" culture=ontarian }
+2014085 = { name="Duhaime" culture=ontarian }
+2014086 = { name="Bélair" culture=ontarian }
+2014087 = { name="Lecuyer" culture=ontarian }
+2014089 = { name="Soucie" culture=ontarian }
+2014090 = { name="Mattiussi" culture=ontarian }
+2014091 = { name="Pageau" culture=ontarian }
+2014092 = { name="Filiatrault" culture=ontarian }
+2014093 = { name="St. Onge" culture=ontarian }
+2014094 = { name="Dignard" culture=ontarian }
+2014095 = { name="Helmer" culture=ontarian }
+2014096 = { name="L'Ériger" culture=ontarian }
+2014097 = { name="Monestime" culture=ontarian }
+2014098 = { name="Reimer" culture=ontarian }
+2014099 = { name="Despres" culture=ontarian }
+2014100 = { name="Tatartcheff" culture=ontarian }
 
 
 2015000 = { name="Jones" culture=gwladfeg }
@@ -5606,6 +6687,82 @@ coat_of_arms = {
 2017042 = { name="Lindhout" culture=prairielander }
 2017043 = { name="Harper" culture=prairielander }
 2017044 = { name="Decker" culture=prairielander }
+2017045 = { name="Drumhell" culture=prairielander }
+2017046 = { name="Ware" culture=prairielander }
+2017047 = { name="Eykhvald" culture=prairielander }
+2017048 = { name="van Straubenzee" culture=prairielander }
+2017049 = { name="Rodgers" culture=prairielander }
+2017050 = { name="Rutherford" culture=prairielander }
+2017051 = { name="Jonquiere" culture=prairielander }
+2017052 = { name="Sifton" culture=prairielander }
+2017053 = { name="Bardo" culture=prairielander }
+2017054 = { name="Stelmach" culture=prairielander }
+2017055 = { name="Lougheed" culture=prairielander }
+2017056 = { name="Lupul" culture=prairielander }
+2017057 = { name="Wynnyk" culture=prairielander }
+2017058 = { name="Bachman" culture=prairielander }
+2017059 = { name="Soltykewych" culture=prairielander }
+2017060 = { name="Freeland" culture=prairielander }
+2017061 = { name="Doukhobor" culture=prairielander }
+2017062 = { name="Askja" culture=prairielander }
+2017063 = { name="Mosienko" culture=prairielander }
+2017064 = { name="Valgardson" culture=prairielander }
+2017065 = { name="Sivertz" culture=prairielander }
+2017066 = { name="Chong" culture=prairielander }
+2017067 = { name="Thorlakson" culture=prairielander }   
+2017068 = { name="Sokolowski" culture=prairielander }
+2017069 = { name="Schezerbanowicz" culture=prairielander }
+2017070 = { name="Jonasson" culture=prairielander }
+2017071 = { name="Clugston" culture=prairielander }
+2017072 = { name="Kwong" culture=prairielander }
+2017073 = { name="Chipewyan" culture=prairielander }
+2017074 = { name="McMurray" culture=prairielander }
+2017075 = { name="Dziurzynski" culture=prairielander }
+2017076 = { name="Nesterenko" culture=prairielander }
+2017077 = { name="Ottenbreit" culture=prairielander }
+2017078 = { name="Holmstrom" culture=prairielander }
+2017079 = { name="Haultain" culture=prairielander }
+2017080 = { name="Yurdiga" culture=prairielander }
+2017081 = { name="Kvill" culture=prairielander }
+2017082 = { name="LeReverend" culture=prairielander }
+2017083 = { name="Gruschewsky" culture=prairielander }
+2017084 = { name="Tjosvold" culture=prairielander }
+2017085 = { name="Oishi" culture=prairielander }
+2017086 = { name="Klaehn" culture=prairielander }
+2017087 = { name="Niderost" culture=prairielander }
+2017088 = { name="Kuemper" culture=prairielander }
+2017089 = { name="Skrudland" culture=prairielander }
+2017090 = { name="Gryba" culture=prairielander }
+2017091 = { name="Szumigalski" culture=prairielander }
+2017092 = { name="Tarbox" culture=prairielander }
+2017093 = { name="Rodehutskors" culture=prairielander }
+2017094 = { name="Kosolofski" culture=prairielander }
+2017095 = { name="Hargreaves" culture=prairielander }
+2017096 = { name="Nawaz" culture=prairielander }
+2017097 = { name="McGeough" culture=prairielander }
+2017098 = { name="Lukiwski" culture=prairielander }
+2017099 = { name="Kiyooka" culture=prairielander }
+2017100 = { name="Milgaard" culture=prairielander }
+2017101 = { name="Hoefsloot" culture=prairielander }
+2017102 = { name="Slingerland" culture=prairielander }
+2017103 = { name="Kirczenow" culture=prairielander }
+2017104 = { name="Redekopp" culture=prairielander }
+2017105 = { name="Knutson" culture=prairielander }
+2017106 = { name="Villebrun" culture=prairielander }
+2017107 = { name="Fryzuk" culture=prairielander }
+2017108 = { name="Boykowich" culture=prairielander }
+2017109 = { name="McElrea" culture=prairielander }
+2017110 = { name="Gazan" culture=prairielander }
+2017111 = { name="Notley" culture=prairielander }
+2017112 = { name="Wowk" culture=prairielander }
+2017113 = { name="Dushenski" culture=prairielander }
+2017114 = { name="Yusep" culture=prairielander }
+2017115 = { name="Hushlak" culture=prairielander }
+2017116 = { name="Prentice" culture=prairielander }
+2017117 = { name="Shandro" culture=prairielander }
+2017118 = { name="Lautermilch" culture=prairielander }
+2017119 = { name="Skowronski" culture=prairielander }
+2017120 = { name="Bjornerud" culture=prairielander }
 
 2018000 = { name="Roberts" culture=liberian }
 2018001 = { name="Benson" culture=liberian }
@@ -5675,18 +6832,136 @@ coat_of_arms = {
 2020009 = { name="Wawakapewin" culture=ojicree }
 2020010 = { name="Webequie" culture=ojicree }
 2020011 = { name="Wunnumin" culture=ojicree }
+2020012 = { name="Kamenawatamin" culture=ojicree }
+2020013 = { name="Beardy" culture=ojicree }
+2020014 = { name="Fiddler" culture=ojicree }
+2020015 = { name="Kakegamic" culture=ojicree }
+2020016 = { name="McDowell" culture=ojicree }
+2020017 = { name="Masakeyash" culture=ojicree }
+2020018 = { name="Roundhead" culture=ojicree }
+2020019 = { name="Mequanawap" culture=ojicree }
+2020020 = { name="Sakakeep" culture=ojicree }
+2020021 = { name="Sakchekapo" culture=ojicree }
+2020022 = { name="Quequeish" culture=ojicree }
+2020023 = { name="Wasakimik" culture=ojicree }
+2020024 = { name="McKoop" culture=ojicree }
+2020025 = { name="Winnepetonga" culture=ojicree }
+2020026 = { name="Mamakwa" culture=ojicree }
+2020027 = { name="Kramer" culture=ojicree }
+2020028 = { name="Zhibwagama" culture=ojicree }
+2020029 = { name="Koocheching" culture=ojicree }
+2020030 = { name="Constance" culture=ojicree }
+2020031 = { name="Tozer" culture=ojicree }
+2020032 = { name="Taipale" culture=ojicree }
+2020033 = { name="Birnie" culture=ojicree }
+2020034 = { name="Peckwatow" culture=ojicree }
+2020035 = { name="Iserhoff" culture=ojicree }
+2020036 = { name="Icebound" culture=ojicree }
+2020037 = { name="Jimmican" culture=ojicree }
+2020038 = { name="Thiso" culture=ojicree }
+2020039 = { name="Tserbrozq" culture=ojicree }
+2020040 = { name="Renouq" culture=ojicree }
+2020041 = { name="Sokeway" culture=ojicree }
+2020042 = { name="Turnak" culture=ojicree }
+2020043 = { name="Telogakyhil" culture=ojicree }
+2020044 = { name="Puskrouth" culture=ojicree }
+2020045 = { name="Nikoskee" culture=ojicree }
+2020046 = { name="Hatchecke" culture=ojicree }
+2020047 = { name="Renouq" culture=ojicree }
+2020048 = { name="Jacfranuer" culture=ojicree }
+2020049 = { name="Bekonung" culture=ojicree }
+2020050 = { name="Domcinadt" culture=ojicree }
+2020051 = { name="Edowiolkoth" culture=ojicree }
+2020052 = { name="La Mace" culture=ojicree }
+2020053 = { name="Eskabalt" culture=ojicree }
+2020054 = { name="Debruigi" culture=ojicree }
+2020056 = { name="Taivosquai" culture=ojicree }
+2020057 = { name="Pheacault" culture=ojicree }
+2020058 = { name="Wabazglieko" culture=ojicree }
+2020059 = { name="Brusgylik" culture=ojicree }
+2020060 = { name="Guakgechiq" culture=ojicree }
+2020061 = { name="Udgarten" culture=ojicree }
+2020062 = { name="Shobekezhik" culture=ojicree }
+2020063 = { name="Nabowyabo" culture=ojicree }
+2020064 = { name="Orsby" culture=ojicree }
+2020065 = { name="Zuaqua-Melroy" culture=ojicree }
+2020066 = { name="Vitmaway" culture=ojicree }
+2020067 = { name="Qgiemanept" culture=ojicree }
+2020068 = { name="Paisudewind" culture=ojicree }
+2020069 = { name="Octazwayjick" culture=ojicree }
+2020070 = { name="Musahkekah" culture=ojicree }
+2020071 = { name="Aestpwaseel" culture=ojicree }
+2020072 = { name="Angukeack" culture=ojicree }
+2020073 = { name="Iogawaskook" culture=ojicree }
+2020074 = { name="Loakastabis" culture=ojicree }
+2020075 = { name="Rabazanah" culture=ojicree }
+2020076 = { name="Jahkabmekak" culture=ojicree }
+2020077 = { name="Neltanowan" culture=ojicree }
+2020078 = { name="Nousakovres" culture=ojicree }
+2020079 = { name="Chamanquan" culture=ojicree }
+2020080 = { name="Chekawasking" culture=ojicree }
+2020081 = { name="Coushang" culture=ojicree }
+2020082 = { name="Esquageseck" culture=ojicree }
+2020083 = { name="Gsquaas" culture=ojicree }
+2020084 = { name="Ozawrosweich" culture=ojicree }
+2020085 = { name="Wksarwah" culture=ojicree }
+2020086 = { name="Sleaushah" culture=ojicree }
+2020087 = { name="Sayseheguan" culture=ojicree }
+2020088 = { name="Mauville" culture=ojicree }
+2020089 = { name="Akudabeek" culture=ojicree }
+2020090 = { name="Abelanagugh" culture=ojicree }
+2020091 = { name="Abelanagugh" culture=ojicree }
+2020092 = { name="Tookforaans" culture=ojicree }
+2020093 = { name="Gindakoguset" culture=ojicree }
+2020094 = { name="Bachickaison" culture=ojicree }
+2020095 = { name="Bullon-Angouis" culture=ojicree }
+2020096 = { name="Eqaasjeegekook" culture=ojicree }
+2020097 = { name="Amstohewanshas" culture=ojicree }
+2020098 = { name="Wlesau" culture=ojicree }
+2020099 = { name="Quahatch" culture=ojicree }
+2020100 = { name="Mlonakykang" culture=ojicree }
 
 2021000 = { name="Siksika" culture=blackfoot }
 2021001 = { name="Kainai" culture=blackfoot }
 2021002 = { name="Piegan" culture=blackfoot }
-2021003 = { name="Belknap" culture=blackfoot }
-2021004 = { name="Tsuu T'ina" culture=blackfoot }
+2021003 = { name="Akaenamax" culture=blackfoot }
+2021004 = { name="Inipoyex" culture=blackfoot }
 2021005 = { name="Atsina" culture=blackfoot }
 2021006 = { name="Tsuut'ina" culture=blackfoot }
-2021007 = { name="Browning" culture=blackfoot }
-2021008 = { name="Glacier" culture=blackfoot }
+2021007 = { name="Ayomokekax" culture=blackfoot }
+2021008 = { name="Calf-Robe" culture=blackfoot }
 2021009 = { name="Isapo-Muxika" culture=blackfoot }
 2021010 = { name="Akay-nehka-simi" culture=blackfoot }
+2021011 = { name="Nitayxkax" culture=blackfoot }
+2021012 = { name="Ak-Ke-Ko-Len" culture=blackfoot }
+2021013 = { name="Skiuhushu" culture=blackfoot }
+2021014 = { name="Marule" culture=blackfoot }
+2021015 = { name="Reevis" culture=blackfoot }
+2021016 = { name="Urquidez" culture=blackfoot }
+2021017 = { name="Tisoyake" culture=blackfoot }
+2021018 = { name="Grevett" culture=blackfoot }
+2021019 = { name="Naranjo" culture=blackfoot }
+2021020 = { name="LaBoeuff" culture=blackfoot }
+2021021 = { name="Apa'tosee" culture=blackfoot }
+2021022 = { name="Aamsskaapipikani" culture=blackfoot }
+2021023 = { name="Haaninin" culture=blackfoot }
+2021024 = { name="Magusis" culture=blackfoot }
+2021025 = { name="Mikahestow" culture=blackfoot }
+2021026 = { name="Mamyowis" culture=blackfoot }
+2021027 = { name="Naranjo" culture=blackfoot }
+2021028 = { name="Minixi" culture=blackfoot }
+2021029 = { name="Kipp" culture=blackfoot }
+2021030 = { name="Medlocke" culture=blackfoot }
+2021031 = { name="Domdon" culture=blackfoot }
+2021032 = { name="Paskwayhk" culture=blackfoot }
+2021033 = { name="Napodiscutchi" culture=blackfoot }
+2021034 = { name="Jucham" culture=blackfoot }
+2021035 = { name="Looding" culture=blackfoot }
+2021036 = { name="Slondains" culture=blackfoot }
+2021037 = { name="No" culture=blackfoot }
+2021038 = { name="Four-Horns" culture=blackfoot }
+2021039 = { name="Kolkakra" culture=blackfoot }
+2021040 = { name="Kobyshin" culture=blackfoot }
 
 
 2022000 = { name="Carlana" culture=apache }


### PR DESCRIPTION
Added dynasties for Inuit, Newfie, Innu, Maritimer, Mi'kmaq, Quebecois, Ojicree, Ojibwe, Ontarian, Ontarois, Algonquin, Metis, Cree, Prairielander, Sioux, Blackfoot, and Canuck
