### PR TITLE
Fix a few bugs with the Paul Mahonic event chain

### DIFF
--- a/After the End Fan Fork/events/paul_mahonic_events.txt
+++ b/After the End Fan Fork/events/paul_mahonic_events.txt
@@ -475,7 +475,7 @@ character_event = { #Offer from land-wanting guy 2 (saboteur)
 		hidden_tooltip = {
 			new_character = {
 				FROM = {
-					letter_event = {
+					character_event = {
 						id = paul_mahonic.15 #Evidence found of reason to attack Mahonics
 						days = 10
 						random = 5
@@ -501,7 +501,7 @@ character_event = { #Offer from land-wanting guy 2 (saboteur)
 	}
 }
 
-letter_event = { #Evidence used
+character_event = { #Evidence used
 	id = paul_mahonic.15
 	desc = EVTDESC_mahonic15
 	picture = GFX_evt_recieve_letter
@@ -553,7 +553,7 @@ character_event = { #Miskaton start- want to get Boston for themselves
 	has_character_flag = miskaton_flag
 	trigger = {
 		c_boston = {
-			holder = {
+			holder_scope = {
 				character = 1620100 #prevent redcoat stuff
 			}
 		}

--- a/After the End Fan Fork/events/paul_mahonic_events.txt
+++ b/After the End Fan Fork/events/paul_mahonic_events.txt
@@ -67,7 +67,7 @@ character_event = { #get an offer from a band of troops
 	}
 }
 
-character_event = { #something suspicious happening in Boston (Miskatons) (fix char that shows up)
+character_event = { #something suspicious happening in Boston (Miskatons)
 	id = paul_mahonic.3
 	desc = EVTDESC_mahonic3
 	picture = GFX_evt_spymaster
@@ -354,6 +354,7 @@ character_event = { #Offer from land-wanting guy
 		name = EVTOPTA_mahonic12
 		wealth = 10
 		hidden_tooltip = {
+			set_character_flag = paul_mahonic_accepted_guy
 			change_variable = { which = paul_mahonic_troops_var value = 800 }
 			liege = {
 				character_event = {
@@ -550,6 +551,13 @@ character_event = { #Miskaton start- want to get Boston for themselves
 	#border = GFX_event_normal_frame
 	#Conditions
 	has_character_flag = miskaton_flag
+	trigger = {
+		c_boston = {
+			holder = {
+				character = 1620100 #prevent redcoat stuff
+			}
+		}
+	}
 	
 	mean_time_to_happen = {
 		days = 1
@@ -1183,6 +1191,17 @@ character_event = { #victory
 		name = EVTOPTA_mahonic27
 		set_character_flag = paul_mahonic_won_independence_war
 		prestige = 100
+		hidden_tooltip = {
+			any_neighbor_independent_ruler = {
+				limit = {
+					dynasty = 1787048
+				}
+				ROOT = {
+					set_truce = { who = PREV years = 0 } #overrides prev truce with a nonexistent one
+				}
+				set_truce = { who = ROOT years = 0 } #overrides prev truce with a nonexistent one
+			}
+		}
 	}
 }
 

--- a/After the End Fan Fork/history/titles/c_boston.txt
+++ b/After the End Fan Fork/history/titles/c_boston.txt
@@ -1,6 +1,6 @@
 2598.1.7 = {
 	holder = 1620060
-	law = succ_tanistry
+	law = succ_elective_gavelkind
 }
 2627.1.1 = {
 	liege="d_nogad"

--- a/After the End Fan Fork/localisation/00_am_events2.csv
+++ b/After the End Fan Fork/localisation/00_am_events2.csv
@@ -2977,11 +2977,11 @@ EVTDESC_mahonic29;Paul Mahonic has refused to grant the titles of Worcester and 
 EVTOPTA_mahonic29;Kill him!;;;;;;;;;;;;;x
 EVTDESC_mahonic30;In the middle of the night, you are awakened by the knock of metal on your door. Someone muttering about "unpaid debts" is all you can hear before feeling a sharp pain in your neck...;;;;;;;;;;;;;x
 EVTOPTA_mahonic30;No...!;;;;;;;;;;;;;x
-EVTDESC_mahonic31;Last night, your guards fought and killed a man attempting to make his way to your chambers. Although he could not be interrogated to determine his employer, an envelope from "Stallton" was found near his body.;;;;;;;;;;;;;x
+EVTDESC_mahonic31;Last night, your guards fought and killed a man attempting to make his way to your chambers. Although he could not be interrogated to determine his employer, an envelope from the claimant you sought help from was found near his body.;;;;;;;;;;;;;x
 EVTOPTA_mahonic31;That bastard...!;;;;;;;;;;;;;x
 EVTDESC_mahonic32;Now that you have united and stabilized your newly independent realm, it is time to look outwards to the remaining parts of New England. Uniting the old heartland of Vincent Mahonic's empire, as well as the Occultist faith, will be crucial to ensuring that all Occultists recognize you as the continuation of the old empire.;;;;;;;;;;;;;x
 EVTOPTA_mahonic32;Onwards!;;;;;;;;;;;;;x
-EVTDESC_mahonic33;Now that you control enough of New England to be recognized as the de jure ruler of the kingdom, it is time to fully unite the region. The Duchy of Connecticut, which had previously been considered a core part of New England but fell under the influence of the Gothamites when the old empire collapsed, will be vital to retake to be recognized as a successor to Vincent Mahonic.;;;;;;;;;;;;;x
+EVTDESC_mahonic33;Now that you control enough of New England to be recognized as its de jure ruler, it is time to fully unite the region, including the Duchy of Connecticut, which was once considered a core part of New England but fell into the Gothamite sphere when the old empire collapsed. All of New England will be vital to retake to be recognized as a successor to Vincent Mahonic.;;;;;;;;;;;;;x
 EVTOPTA_mahonic33;To birthright!;;;;;;;;;;;;;x
 EVTDESC_mahonic34;Finally, New England has been united under the Mahonic dynasty once again. Despite this, much work remains to be done, to reclaim for New England the stature it had under the old empire. Diplomacy, economics, and more will be vital to achieving this goal, and there is no better time to start than now.;;;;;;;;;;;;;x
 EVTOPTA_mahonic34;Victory!;;;;;;;;;;;;;x


### PR DESCRIPTION
- Prevent the chain from firing in the Redcoat bookmark
- Enable the Subjugation CB for Paul Mahonic by switching him to Elective Gavelkind
- Remove the truce after the war
- Fix an issue preventing the claimant from demanding land
- Switch a letter event to character
- Minorly rewrite the loc for one event